### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# Below is a list of White Whale team members' GitHub handles who are
+# suggested reviewers for contributions to this repository.
+#
+# These names are just suggestions. It is fine to have your changes
+# reviewed by someone else.
+#
+# Use git ls-files '<pattern>' without a / prefix to see the list of matching files.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# to learn how to customize this file.
+
+*           @kerber0x @0xFable @kaimen-sano


### PR DESCRIPTION
This file adds a list of codeowners. 

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners