### PR TITLE
Wrong link to Contribution guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Getting started
 
-To get started with `migaloo-core`, please go through the [contributing guide](./CONTRIBUTING.md) to see the 
+To get started with `migaloo-core`, please go through the [contributing guide](./docs/CONTRIBUTING.md) to see the 
 different ways to contribute to the project.
 
 ## Resources


### PR DESCRIPTION
gm, the link to the Contributing guide within the Getting started section was incorrect, leading to a non existing page.

## Description and Motivation
  The link to the Contributing guide within the Getting started section was incorrect, leading to a non existing page.
<!-- 
    


-->

## Related Issues
   Before: https://github.com/White-Whale-Defi-Platform/white-whale-core/blob/main/CONTRIBUTING.md
   After:    https://github.com/White-Whale-Defi-Platform/white-whale-core/blob/main/docs/CONTRIBUTING.md
<!-- 
    


-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
