### PR TITLE
Fix/deploy pool script

### DIFF
--- a/scripts/deployment/deploy_pool.sh
+++ b/scripts/deployment/deploy_pool.sh
@@ -62,7 +62,7 @@ function check_decimals() {
     # the factory doesn't have the decimals for this denom, registration needs to happen before creating the pool
     add_native_decimals_msg='{"add_native_token_decimals":{"denom":"'$denom'","decimals":'$decimals'}}'
 
-    local res=$($BINARY tx wasm execute $pool_factory_addr "$add_native_decimals_msg" $TXFLAG --amount 1$DENOM --from $deployer_address)
+    local res=$($BINARY tx wasm execute $pool_factory_addr "$add_native_decimals_msg" $TXFLAG --amount 1$denom --from $deployer_address)
     echo $res
     sleep $tx_delay
   fi


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR improves the `deploy_pool` script by adding a label to the ouput.

So instead of having the obscure reference `pair:  ibc/C4CF...19F9-ibc/107D...5CBF` it will also provide with something meaningful like `label: uatom-uluna` doing denom-trance queries for ibc tokens.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
