### PR TITLE
Fix/token factory lp denom creation fail issue

### DIFF
--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    to_binary, wasm_execute, CosmosMsg, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg,
+    to_binary, wasm_execute, CosmosMsg, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg, MessageInfo
 };
 
 use pool_network::asset::{AssetInfo, PairType};
@@ -74,6 +74,7 @@ pub fn update_pair_config(
 pub fn create_pair(
     deps: DepsMut,
     env: Env,
+    info: MessageInfo,
     asset_infos: [AssetInfo; 2],
     pool_fees: PoolFee,
     pair_type: PairType,
@@ -144,7 +145,7 @@ pub fn create_pair(
             gas_limit: None,
             msg: CosmosMsg::Wasm(WasmMsg::Instantiate {
                 code_id: config.pair_code_id,
-                funds: vec![],
+                funds: info.funds.clone(),
                 admin: Some(env.contract.address.to_string()),
                 label: pair_label,
                 msg: to_binary(&PairInstantiateMsg {

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
@@ -146,7 +146,7 @@ pub fn create_pair(
             gas_limit: None,
             msg: CosmosMsg::Wasm(WasmMsg::Instantiate {
                 code_id: config.pair_code_id,
-                funds: info.funds.clone(),
+                funds: info.funds,
                 admin: Some(env.contract.address.to_string()),
                 label: pair_label,
                 msg: to_binary(&PairInstantiateMsg {

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    to_binary, wasm_execute, CosmosMsg, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg, MessageInfo
+    to_binary, wasm_execute, CosmosMsg, DepsMut, Env, MessageInfo, ReplyOn, Response, SubMsg,
+    WasmMsg,
 };
 
 use pool_network::asset::{AssetInfo, PairType};

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
@@ -70,6 +70,7 @@ pub fn execute(
         } => commands::create_pair(
             deps,
             env,
+            info,
             asset_infos,
             pool_fees,
             pair_type,

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/testing.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/testing.rs
@@ -2,8 +2,8 @@ use cosmwasm_std::testing::{
     mock_dependencies_with_balance, mock_env, mock_info, MockApi, MockStorage, MOCK_CONTRACT_ADDR,
 };
 use cosmwasm_std::{
-    attr, coin, from_binary, to_binary, Api, CanonicalAddr, CosmosMsg, Decimal, OwnedDeps, Reply,
-    ReplyOn, Response, SubMsg, SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
+    attr, coin, from_binary, to_binary, Api, CanonicalAddr, Coin, CosmosMsg, Decimal, OwnedDeps,
+    Reply, ReplyOn, Response, SubMsg, SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
 };
 
 use pool_network::asset::{AssetInfo, AssetInfoRaw, PairInfo, PairInfoRaw, PairType};
@@ -193,7 +193,13 @@ fn create_pair() {
     };
 
     let env = mock_env();
-    let info = mock_info("addr0000", &[]);
+    let info = mock_info(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::new(1u128),
+        }],
+    );
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
     assert_eq!(
         res.attributes,
@@ -232,7 +238,11 @@ fn create_pair() {
                 })
                 .unwrap(),
                 code_id: 321u64,
-                funds: vec![],
+                funds: [Coin {
+                    denom: "uusd".to_string(),
+                    amount: Uint128::new(1u128),
+                }]
+                .to_vec(),
                 label: "uusd-mAAPL pair".to_string(),
                 admin: Some(MOCK_CONTRACT_ADDR.to_string()),
             }

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/migrations.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/migrations.rs
@@ -147,7 +147,9 @@ pub fn migrate_to_v130(deps: DepsMut) -> Result<(), StdError> {
             asset_infos: config.asset_infos,
             contract_addr: config.contract_addr,
             // all liquidity tokens until this version are cw20 tokens
-            liquidity_token: AssetInfoRaw::Token { contract_addr: config.liquidity_token },
+            liquidity_token: AssetInfoRaw::Token {
+                contract_addr: config.liquidity_token,
+            },
             asset_decimals: config.asset_decimals,
             // all pools until this version are ConstantProduct
             pair_type: PairType::ConstantProduct,


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR implements the changes to fix audit issue#2 (Creating a token factory denom will always fail due to insufficient denom creation fee) reported by SCV


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
