### PR TITLE
fix: include amp factor when calculating slippage on stableswap

### DIFF
--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/helpers.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/helpers.rs
@@ -383,6 +383,9 @@ pub fn assert_slippage_tolerance(
     slippage_tolerance: &Option<Decimal>,
     deposits: &[Uint128; 2],
     pools: &[Asset; 2],
+    pair_type: PairType,
+    amount: Uint128,
+    pool_token_supply: Uint128,
 ) -> Result<(), ContractError> {
     if let Some(slippage_tolerance) = *slippage_tolerance {
         let slippage_tolerance: Decimal256 = slippage_tolerance.into();
@@ -395,12 +398,31 @@ pub fn assert_slippage_tolerance(
         let pools: [Uint256; 2] = [pools[0].amount.into(), pools[1].amount.into()];
 
         // Ensure each prices are not dropped as much as slippage tolerance rate
-        if Decimal256::from_ratio(deposits[0], deposits[1]) * one_minus_slippage_tolerance
-            > Decimal256::from_ratio(pools[0], pools[1])
-            || Decimal256::from_ratio(deposits[1], deposits[0]) * one_minus_slippage_tolerance
-                > Decimal256::from_ratio(pools[1], pools[0])
-        {
-            return Err(ContractError::MaxSlippageAssertion {});
+        match pair_type {
+            PairType::StableSwap { .. } => {
+                let pools_total = pools[0].checked_add(pools[1])?;
+                let deposits_total = deposits[0].checked_add(deposits[1])?;
+
+                let pool_ratio = Decimal256::from_ratio(pools_total, pool_token_supply);
+                let deposit_ratio = Decimal256::from_ratio(deposits_total, amount);
+
+                // the slippage tolerance for the stableswap can't use a simple ratio for calculating
+                // slippage when adding liquidity. Due to the math behind the stableswap, the amp factor
+                // needs to be in as well, much like when swaps are done
+                if pool_ratio * one_minus_slippage_tolerance > deposit_ratio {
+                    return Err(ContractError::MaxSlippageAssertion {});
+                }
+            }
+            PairType::ConstantProduct => {
+                if Decimal256::from_ratio(deposits[0], deposits[1]) * one_minus_slippage_tolerance
+                    > Decimal256::from_ratio(pools[0], pools[1])
+                    || Decimal256::from_ratio(deposits[1], deposits[0])
+                        * one_minus_slippage_tolerance
+                        > Decimal256::from_ratio(pools[1], pools[0])
+                {
+                    return Err(ContractError::MaxSlippageAssertion {});
+                }
+            }
         }
     }
 

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
@@ -746,6 +746,9 @@ fn test_assert_slippage_tolerance_invalid_ratio() {
                 amount: Default::default(),
             },
         ],
+        PairType::ConstantProduct,
+        Default::default(),
+        Default::default(),
     );
 
     match res {


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

The slippage tolerance when adding liquidity is using a simple ratio, which does not apply with the stableswap algorithm.  The amp factor needs to be considered here.


## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

#131

https://github.com/White-Whale-Defi-Platform/white-whale-core/pull/131/commits/596bb43fab6fa6ed90419c3ed2cbbcef48ef96ee

---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
