### PR TITLE
fix(fee_distributor): fix edge case where the contract would error due to expired epochs becoming claimable

### DIFF
--- a/contracts/liquidity_hub/fee_distributor/src/state.rs
+++ b/contracts/liquidity_hub/fee_distributor/src/state.rs
@@ -77,6 +77,11 @@ pub fn query_claimable(deps: Deps, address: &Addr) -> StdResult<ClaimableEpochsR
         claimable_epochs.retain(|epoch| epoch.id > last_claimed_epoch);
     };
 
+    // filter out epochs that have no available fees. This would only happen in case the grace period
+    // gets increased after epochs have expired, which would lead to make them available for claiming
+    // again without any available rewards, as those were forwarded to newer epochs.
+    claimable_epochs.retain(|epoch| !epoch.available.is_empty());
+
     Ok(ClaimableEpochsResponse {
         epochs: claimable_epochs,
     })


### PR DESCRIPTION

## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->
This PR implements a fix for an edge case on the fee distributor, causing errors when trying to claim rewards from expired epochs.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
