### PR TITLE
fix: tweak weight calculation on bonding contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "fee_distributor"
-version = "1.0.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1499,7 +1499,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whale-lair"
-version = "1.0.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/liquidity_hub/fee_distributor/Cargo.toml
+++ b/contracts/liquidity_hub/fee_distributor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fee_distributor"
-version = "1.0.0"
+version = "0.8.0"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "Contract to distribute the fees collected by the Fee Collector."

--- a/contracts/liquidity_hub/whale_lair/Cargo.toml
+++ b/contracts/liquidity_hub/whale_lair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whale-lair"
-version = "1.0.0"
+version = "0.8.0"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "The Whale Lair is a bonding contract used to bond WHALE LSDs."

--- a/contracts/liquidity_hub/whale_lair/src/state.rs
+++ b/contracts/liquidity_hub/whale_lair/src/state.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{Addr, Decimal, DepsMut, StdError, StdResult, Timestamp, Uint128};
 use cw_storage_plus::{Item, Map};
-use white_whale::pool_network::asset::AssetInfo;
 
+use white_whale::pool_network::asset::AssetInfo;
 use white_whale::whale_lair::{Bond, Config, GlobalIndex};
 
 use crate::ContractError;
@@ -74,12 +74,16 @@ pub fn get_weight(
     growth_rate: Decimal,
     timestamp: Timestamp,
 ) -> StdResult<Uint128> {
-    let time_factor = Uint128::from(
-        current_timestamp
-            .seconds()
-            .checked_sub(timestamp.seconds())
-            .ok_or_else(|| StdError::generic_err("Error calculating time_factor"))?,
-    );
+    let time_factor = if timestamp == Timestamp::default() {
+        Uint128::zero()
+    } else {
+        Uint128::from(
+            current_timestamp
+                .seconds()
+                .checked_sub(timestamp.seconds())
+                .ok_or_else(|| StdError::generic_err("Error calculating time_factor"))?,
+        )
+    };
 
     Ok(weight.checked_add(amount.checked_mul(time_factor)? * growth_rate)?)
 }


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR tweaks the weight calculation on the bonding contract, making it 0 on the initial bonding.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
