### PR TITLE
refactor: make cosmwasm 1.1 feature optional

### DIFF
--- a/.github/workflows/ci-test-fmt-check.yaml
+++ b/.github/workflows/ci-test-fmt-check.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.15.0'
-          args: '--features "injective" --locked -- --test-threads 1'
+          args: '--features "injective token_factory" --locked -- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "stableswap-3pool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "terraswap-pair"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "white-whale"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ publish = false
 
 [workspace.dependencies]
 cosmwasm-schema = "1.1.4"
-cosmwasm-std = { version = "1.1.4", features = ["iterator", "stargate", "cosmwasm_1_1"] }
+cosmwasm-std = { version = "1.1.4", features = ["iterator"] }
 cw2 = "0.15.1"
 cw20 = "0.15.1"
 cw20-base = { version = "0.15.1", features = ["library"] }

--- a/contracts/liquidity_hub/fee_collector/Cargo.toml
+++ b/contracts/liquidity_hub/fee_collector/Cargo.toml
@@ -24,6 +24,8 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
+token_factory = ["white-whale/token_factory"]
+injective = ["white-whale/injective"]
 
 [dependencies]
 cosmwasm-std.workspace = true

--- a/contracts/liquidity_hub/fee_distributor/Cargo.toml
+++ b/contracts/liquidity_hub/fee_distributor/Cargo.toml
@@ -24,6 +24,8 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
+token_factory = ["white-whale/token_factory"]
+injective = ["white-whale/injective"]
 
 [dependencies]
 cosmwasm-schema.workspace = true

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stableswap-3pool"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
 	"Adam J. Weigold <adam@irulast.com>",
 ]
@@ -24,6 +24,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/commands.rs
@@ -1,17 +1,17 @@
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, CosmosMsg, Decimal, DepsMut, Env, MessageInfo,
-    OverflowError, Response, StdError, StdResult, Uint128, WasmMsg,
+    from_binary, to_binary, Addr, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, OverflowError,
+    Response, StdError, StdResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
 use crate::contract::{MAX_AMP, MAX_AMP_CHANGE, MIN_AMP, MIN_RAMP_BLOCKS};
-use white_whale::pool_network::asset::{
-    Asset, AssetInfo, AssetInfoRaw, TrioInfoRaw, MINIMUM_LIQUIDITY_AMOUNT,
-};
 #[cfg(feature = "token_factory")]
 use cosmwasm_std::coins;
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::asset::is_factory_token;
+use white_whale::pool_network::asset::{
+    Asset, AssetInfo, AssetInfoRaw, TrioInfoRaw, MINIMUM_LIQUIDITY_AMOUNT,
+};
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::{Coin, MsgBurn, MsgMint};
 use white_whale::pool_network::trio::{Config, Cw20HookMsg, FeatureToggle, PoolFee, RampAmp};

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply,
-    Response, StdError, StdResult,
+    to_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    StdResult,
 };
 use cw2::{get_contract_version, set_contract_version};
 use protobuf::Message;
@@ -18,7 +18,8 @@ use crate::error::ContractError::MigrateInvalidVersion;
 use crate::helpers::has_factory_token;
 use crate::response::MsgInstantiateContractResponse;
 use crate::state::{
-    ALL_TIME_BURNED_FEES, ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG, TRIO_INFO,
+    ALL_TIME_BURNED_FEES, ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG,
+    TRIO_INFO,
 };
 use crate::{commands, helpers, queries};
 

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/contract.rs
@@ -1,17 +1,14 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, ReplyOn,
-    Response, StdError, StdResult, SubMsg, WasmMsg,
+    to_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply,
+    Response, StdError, StdResult,
 };
 use cw2::{get_contract_version, set_contract_version};
-use cw20::MinterResponse;
 use protobuf::Message;
 use semver::Version;
 
 use white_whale::pool_network::asset::{AssetInfoRaw, TrioInfoRaw};
-use white_whale::pool_network::denom::MsgCreateDenom;
-use white_whale::pool_network::token::InstantiateMsg as TokenInstantiateMsg;
 use white_whale::pool_network::trio::{
     Config, ExecuteMsg, FeatureToggle, InstantiateMsg, MigrateMsg, QueryMsg,
 };
@@ -21,8 +18,7 @@ use crate::error::ContractError::MigrateInvalidVersion;
 use crate::helpers::has_factory_token;
 use crate::response::MsgInstantiateContractResponse;
 use crate::state::{
-    ALL_TIME_BURNED_FEES, ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG,
-    LP_SYMBOL, TRIO_INFO,
+    ALL_TIME_BURNED_FEES, ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG, TRIO_INFO,
 };
 use crate::{commands, helpers, queries};
 
@@ -30,7 +26,7 @@ use crate::{commands, helpers, queries};
 const CONTRACT_NAME: &str = "white_whale-stableswap-3pool";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const INSTANTIATE_REPLY_ID: u64 = 1;
+pub const INSTANTIATE_REPLY_ID: u64 = 1;
 
 /// Minimum amplification coefficient.
 pub const MIN_AMP: u64 = 1;
@@ -95,7 +91,7 @@ pub fn instantiate(
     let config = Config {
         owner: deps.api.addr_validate(info.sender.as_str())?,
         fee_collector_addr: deps.api.addr_validate(msg.fee_collector_addr.as_str())?,
-        pool_fees: msg.pool_fees,
+        pool_fees: msg.pool_fees.clone(),
         feature_toggle: FeatureToggle {
             withdrawals_enabled: true,
             deposits_enabled: true,
@@ -131,48 +127,7 @@ pub fn instantiate(
         ALL_TIME_BURNED_FEES,
     )?;
 
-    if msg.token_factory_lp {
-        // create native LP token
-        TRIO_INFO.update(deps.storage, |mut trio_info| -> StdResult<_> {
-            let denom = format!("{}/{}/{}", "factory", env.contract.address, LP_SYMBOL);
-            trio_info.liquidity_token = AssetInfoRaw::NativeToken { denom };
-
-            Ok(trio_info)
-        })?;
-
-        Ok(
-            Response::new().add_message(<MsgCreateDenom as Into<CosmosMsg>>::into(
-                MsgCreateDenom {
-                    sender: env.contract.address.to_string(),
-                    subdenom: LP_SYMBOL.to_string(),
-                },
-            )),
-        )
-    } else {
-        Ok(Response::new().add_submessage(SubMsg {
-            // Create LP token
-            msg: WasmMsg::Instantiate {
-                admin: None,
-                code_id: msg.token_code_id,
-                msg: to_binary(&TokenInstantiateMsg {
-                    name: lp_token_name.clone(),
-                    symbol: "uLP".to_string(),
-                    decimals: 6,
-                    initial_balances: vec![],
-                    mint: Some(MinterResponse {
-                        minter: env.contract.address.to_string(),
-                        cap: None,
-                    }),
-                })?,
-                funds: vec![],
-                label: lp_token_name,
-            }
-            .into(),
-            gas_limit: None,
-            id: INSTANTIATE_REPLY_ID,
-            reply_on: ReplyOn::Success,
-        }))
-    }
+    helpers::create_lp_token(deps, &env, &msg, &lp_token_name)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/error.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/error.rs
@@ -48,6 +48,9 @@ pub enum ContractError {
 
     #[error("Burn fee is not allowed when using factory tokens")]
     TokenFactoryAssetBurnDisabled {},
+
+    #[error("The token factory feature is not enabled")]
+    TokenFactoryNotEnabled {},
 }
 
 impl From<semver::Error> for ContractError {

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/helpers.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/helpers.rs
@@ -2,15 +2,15 @@ use std::cmp::Ordering;
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Decimal, Decimal256, Deps, DepsMut, Env, ReplyOn, Response, StdError,
-    StdResult, Storage, SubMsg, Uint128, Uint256, WasmMsg,
+    to_binary, Decimal, Decimal256, Deps, DepsMut, Env, ReplyOn, Response, StdError, StdResult,
+    Storage, SubMsg, Uint128, Uint256, WasmMsg,
 };
 use cw20::MinterResponse;
 use cw_storage_plus::Item;
 
-use white_whale::pool_network::asset::{is_factory_token, Asset, AssetInfo, AssetInfoRaw};
 #[cfg(feature = "token_factory")]
 use cosmwasm_std::CosmosMsg;
+use white_whale::pool_network::asset::{is_factory_token, Asset, AssetInfo, AssetInfoRaw};
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgCreateDenom;
 use white_whale::pool_network::querier::query_token_info;

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/helpers.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/helpers.rs
@@ -1,15 +1,26 @@
 use std::cmp::Ordering;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Decimal, Decimal256, Deps, StdError, StdResult, Storage, Uint128, Uint256};
+use cosmwasm_std::{
+    to_binary, Decimal, Decimal256, Deps, DepsMut, Env, ReplyOn, Response, StdError,
+    StdResult, Storage, SubMsg, Uint128, Uint256, WasmMsg,
+};
+use cw20::MinterResponse;
 use cw_storage_plus::Item;
 
-use white_whale::pool_network::asset::{is_factory_token, Asset, AssetInfo};
+use white_whale::pool_network::asset::{is_factory_token, Asset, AssetInfo, AssetInfoRaw};
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::CosmosMsg;
+#[cfg(feature = "token_factory")]
+use white_whale::pool_network::denom::MsgCreateDenom;
 use white_whale::pool_network::querier::query_token_info;
-use white_whale::pool_network::trio::PoolFee;
+use white_whale::pool_network::token::InstantiateMsg as TokenInstantiateMsg;
+use white_whale::pool_network::trio::{InstantiateMsg, PoolFee};
 
+use crate::contract::INSTANTIATE_REPLY_ID;
 use crate::error::ContractError;
 use crate::stableswap_math::curve::StableSwap;
+use crate::state::{LP_SYMBOL, TRIO_INFO};
 
 pub fn compute_swap(
     offer_pool: Uint128,
@@ -273,6 +284,7 @@ pub fn instantiate_fees(
 
 /// Gets the total supply of the given liquidity token
 pub fn get_total_share(deps: &Deps, liquidity_token: String) -> StdResult<Uint128> {
+    #[cfg(feature = "token_factory")]
     let total_share = if is_factory_token(liquidity_token.as_str()) {
         //bank query total
         deps.querier.query_supply(&liquidity_token)?.amount
@@ -283,6 +295,13 @@ pub fn get_total_share(deps: &Deps, liquidity_token: String) -> StdResult<Uint12
         )?
         .total_supply
     };
+    #[cfg(not(feature = "token_factory"))]
+    let total_share = query_token_info(
+        &deps.querier,
+        deps.api.addr_validate(liquidity_token.as_str())?,
+    )?
+    .total_supply;
+
     Ok(total_share)
 }
 
@@ -293,4 +312,58 @@ pub fn has_factory_token(assets: &[AssetInfo]) -> bool {
         AssetInfo::Token { .. } => false,
         AssetInfo::NativeToken { denom } => is_factory_token(denom),
     })
+}
+
+/// Creates a new LP token for this pool
+pub fn create_lp_token(
+    deps: DepsMut,
+    env: &Env,
+    msg: &InstantiateMsg,
+    lp_token_name: &String,
+) -> Result<Response, ContractError> {
+    if msg.token_factory_lp {
+        // create native LP token
+        TRIO_INFO.update(deps.storage, |mut trio_info| -> StdResult<_> {
+            let denom = format!("{}/{}/{}", "factory", env.contract.address, LP_SYMBOL);
+            trio_info.liquidity_token = AssetInfoRaw::NativeToken { denom };
+
+            Ok(trio_info)
+        })?;
+
+        #[cfg(feature = "token_factory")]
+        return Ok(
+            Response::new().add_message(<MsgCreateDenom as Into<CosmosMsg>>::into(
+                MsgCreateDenom {
+                    sender: env.contract.address.to_string(),
+                    subdenom: LP_SYMBOL.to_string(),
+                },
+            )),
+        );
+        #[allow(unreachable_code)]
+        Err(ContractError::TokenFactoryNotEnabled {})
+    } else {
+        Ok(Response::new().add_submessage(SubMsg {
+            // Create LP token
+            msg: WasmMsg::Instantiate {
+                admin: None,
+                code_id: msg.token_code_id,
+                msg: to_binary(&TokenInstantiateMsg {
+                    name: lp_token_name.to_owned(),
+                    symbol: "uLP".to_string(),
+                    decimals: 6,
+                    initial_balances: vec![],
+                    mint: Some(MinterResponse {
+                        minter: env.contract.address.to_string(),
+                        cap: None,
+                    }),
+                })?,
+                funds: vec![],
+                label: lp_token_name.to_owned(),
+            }
+            .into(),
+            gas_limit: None,
+            id: INSTANTIATE_REPLY_ID,
+            reply_on: ReplyOn::Success,
+        }))
+    }
 }

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/provide_liquidity.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/provide_liquidity.rs
@@ -1,14 +1,18 @@
 use crate::contract::{execute, instantiate, reply};
 use crate::error::ContractError;
-use crate::state::LP_SYMBOL;
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    coin, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg,
+    to_binary, Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg,
     SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::{Asset, AssetInfo, MINIMUM_LIQUIDITY_AMOUNT};
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::{coin, BankMsg};
+#[cfg(feature = "token_factory")]
+use crate::state::LP_SYMBOL;
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgMint;
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::trio::{ExecuteMsg, InstantiateMsg, PoolFee};
@@ -543,8 +547,9 @@ fn provide_liquidity_cw20_lp() {
     let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
-fn provide_liquidity_tokenfactory_lp() {
+fn provide_liquidity_token_factory_lp() {
     let lp_denom = format!("{}/{MOCK_CONTRACT_ADDR}/{LP_SYMBOL}", "factory");
 
     let mut deps = mock_dependencies(&[

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/provide_liquidity.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/provide_liquidity.rs
@@ -1,17 +1,17 @@
 use crate::contract::{execute, instantiate, reply};
 use crate::error::ContractError;
+#[cfg(feature = "token_factory")]
+use crate::state::LP_SYMBOL;
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::{coin, BankMsg};
 use cosmwasm_std::{
-    to_binary, Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg,
-    SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
+    to_binary, Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg, SubMsgResponse,
+    SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::{Asset, AssetInfo, MINIMUM_LIQUIDITY_AMOUNT};
-#[cfg(feature = "token_factory")]
-use cosmwasm_std::{coin, BankMsg};
-#[cfg(feature = "token_factory")]
-use crate::state::LP_SYMBOL;
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgMint;
 use white_whale::pool_network::mock_querier::mock_dependencies;

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/testing.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/testing.rs
@@ -1,13 +1,18 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, CosmosMsg, Decimal, Reply, ReplyOn, StdError, SubMsg,
+    from_binary, to_binary, Addr, Decimal, Reply, ReplyOn, StdError, SubMsg,
     SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::MinterResponse;
 
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::{Asset, AssetInfo, TrioInfo};
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgCreateDenom;
+#[cfg(feature = "token_factory")]
+use crate::state::LP_SYMBOL;
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::CosmosMsg;
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::token::InstantiateMsg as TokenInstantiateMsg;
 use white_whale::pool_network::trio::ExecuteMsg::UpdateConfig;
@@ -17,7 +22,6 @@ use crate::contract::{execute, instantiate, migrate, query, reply};
 use crate::error::ContractError;
 use crate::helpers::{assert_max_spread, assert_slippage_tolerance};
 use crate::queries::query_trio_info;
-use crate::state::LP_SYMBOL;
 
 #[test]
 fn proper_initialization_cw20_lp() {
@@ -130,6 +134,7 @@ fn proper_initialization_cw20_lp() {
     );
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
 fn proper_initialization_tokenfactory_lp() {
     let mut deps = mock_dependencies(&[]);
@@ -197,6 +202,7 @@ fn proper_initialization_tokenfactory_lp() {
     );
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
 fn intialize_with_burnable_token_factory_asset() {
     let mut deps = mock_dependencies(&[]);

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/testing.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/testing.rs
@@ -1,18 +1,18 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, Decimal, Reply, ReplyOn, StdError, SubMsg,
-    SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
+    from_binary, to_binary, Addr, Decimal, Reply, ReplyOn, StdError, SubMsg, SubMsgResponse,
+    SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::MinterResponse;
 
-use white_whale::fee::Fee;
-use white_whale::pool_network::asset::{Asset, AssetInfo, TrioInfo};
-#[cfg(feature = "token_factory")]
-use white_whale::pool_network::denom::MsgCreateDenom;
 #[cfg(feature = "token_factory")]
 use crate::state::LP_SYMBOL;
 #[cfg(feature = "token_factory")]
 use cosmwasm_std::CosmosMsg;
+use white_whale::fee::Fee;
+use white_whale::pool_network::asset::{Asset, AssetInfo, TrioInfo};
+#[cfg(feature = "token_factory")]
+use white_whale::pool_network::denom::MsgCreateDenom;
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::token::InstantiateMsg as TokenInstantiateMsg;
 use white_whale::pool_network::trio::ExecuteMsg::UpdateConfig;

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
@@ -1,15 +1,20 @@
 use crate::contract::{execute, instantiate, reply};
 use crate::error::ContractError;
-use crate::state::{get_fees_for_asset, store_fee, COLLECTED_PROTOCOL_FEES, LP_SYMBOL};
+use crate::state::{get_fees_for_asset, store_fee, COLLECTED_PROTOCOL_FEES};
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    attr, coin, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, SubMsg, SubMsgResponse,
+    attr, to_binary, Coin, CosmosMsg, Decimal, Reply, SubMsg, SubMsgResponse,
     SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::AssetInfo;
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgBurn;
+#[cfg(feature = "token_factory")]
+use crate::state::LP_SYMBOL;
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::{coin, BankMsg};
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::trio::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, PoolFee};
 
@@ -204,6 +209,7 @@ fn withdraw_liquidity_cw20_lp() {
     );
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
 fn withdraw_liquidity_token_factory_lp() {
     let lp_denom = format!("{}/{MOCK_CONTRACT_ADDR}/{LP_SYMBOL}", "factory");
@@ -327,6 +333,7 @@ fn withdraw_liquidity_token_factory_lp() {
     );
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
 fn withdraw_liquidity_token_factory_lp_wrong_asset() {
     let lp_denom = format!("{}/{MOCK_CONTRACT_ADDR}/{LP_SYMBOL}", "factory");

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
@@ -1,20 +1,20 @@
 use crate::contract::{execute, instantiate, reply};
 use crate::error::ContractError;
+#[cfg(feature = "token_factory")]
+use crate::state::LP_SYMBOL;
 use crate::state::{get_fees_for_asset, store_fee, COLLECTED_PROTOCOL_FEES};
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    attr, to_binary, Coin, CosmosMsg, Decimal, Reply, SubMsg, SubMsgResponse,
-    SubMsgResult, Uint128, WasmMsg,
+    attr, to_binary, Coin, CosmosMsg, Decimal, Reply, SubMsg, SubMsgResponse, SubMsgResult,
+    Uint128, WasmMsg,
 };
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::{coin, BankMsg};
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::AssetInfo;
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgBurn;
-#[cfg(feature = "token_factory")]
-use crate::state::LP_SYMBOL;
-#[cfg(feature = "token_factory")]
-use cosmwasm_std::{coin, BankMsg};
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::trio::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, PoolFee};
 

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
@@ -25,6 +25,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-pair"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
 	"Terraform Labs, PTE.",
 	"DELIGHT LABS",
@@ -28,6 +28,7 @@ crate-type = ["cdylib", "rlib"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
+token_factory = ["white-whale/token_factory"]
 
 [dependencies]
 cw2.workspace = true

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
@@ -28,6 +28,7 @@ crate-type = ["cdylib", "rlib"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
+injective = ["white-whale/injective"]
 token_factory = ["white-whale/token_factory"]
 
 [dependencies]

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/commands.rs
@@ -1,12 +1,17 @@
 use cosmwasm_std::{
-    coins, from_binary, to_binary, Addr, CosmosMsg, Decimal, DepsMut, Env, MessageInfo,
+    from_binary, to_binary, Addr, CosmosMsg, Decimal, DepsMut, Env, MessageInfo,
     OverflowError, Response, StdError, StdResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
 use white_whale::pool_network::asset::{
-    is_factory_token, Asset, AssetInfo, AssetInfoRaw, PairInfoRaw, MINIMUM_LIQUIDITY_AMOUNT,
+    Asset, AssetInfo, AssetInfoRaw, PairInfoRaw, MINIMUM_LIQUIDITY_AMOUNT,
 };
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::coins;
+#[cfg(feature = "token_factory")]
+use white_whale::pool_network::asset::is_factory_token;
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::{Coin, MsgBurn, MsgMint};
 use white_whale::pool_network::pair::{Config, Cw20HookMsg, FeatureToggle, PoolFee};
 use white_whale::pool_network::U256;
@@ -297,8 +302,7 @@ pub fn withdraw_liquidity(
 
     let refund_assets = refund_assets?;
 
-    let burn_lp_token_msg =
-        burn_lp_token_msg(liquidity_token, env.contract.address.to_string(), amount)?;
+    let burn_lp_token_msg = burn_lp_token_msg(liquidity_token, env.contract.address.to_string(), amount)?;
 
     // update pool info
     Ok(Response::new()
@@ -559,12 +563,14 @@ pub fn collect_protocol_fees(deps: DepsMut) -> Result<Response, ContractError> {
 }
 
 /// Creates the Mint LP message
+#[allow(unused_variables)]
 fn mint_lp_token_msg(
     liquidity_token: String,
     recipient: String,
     sender: String,
     amount: Uint128,
 ) -> Result<Vec<CosmosMsg>, ContractError> {
+    #[cfg(feature = "token_factory")]
     if is_factory_token(liquidity_token.as_str()) {
         let mut messages = vec![];
         messages.push(<MsgMint as Into<CosmosMsg>>::into(MsgMint {
@@ -590,14 +596,24 @@ fn mint_lp_token_msg(
             funds: vec![],
         })])
     }
+
+    #[cfg(not(feature = "token_factory"))]
+    Ok(vec![CosmosMsg::Wasm(WasmMsg::Execute {
+        contract_addr: liquidity_token,
+        msg: to_binary(&Cw20ExecuteMsg::Mint { recipient, amount })?,
+        funds: vec![],
+    })])
 }
 
+
 /// Creates the Burn LP message
+#[allow(unused_variables)]
 fn burn_lp_token_msg(
     liquidity_token: String,
     sender: String,
     amount: Uint128,
 ) -> Result<CosmosMsg, ContractError> {
+    #[cfg(feature = "token_factory")]
     if is_factory_token(liquidity_token.as_str()) {
         Ok(<MsgBurn as Into<CosmosMsg>>::into(MsgBurn {
             sender,
@@ -613,4 +629,10 @@ fn burn_lp_token_msg(
             funds: vec![],
         }))
     }
+    #[cfg(not(feature = "token_factory"))]
+    Ok(CosmosMsg::Wasm(WasmMsg::Execute {
+        contract_addr: liquidity_token,
+        msg: to_binary(&Cw20ExecuteMsg::Burn { amount })?,
+        funds: vec![],
+    }))
 }

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/commands.rs
@@ -1,16 +1,16 @@
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, CosmosMsg, Decimal, DepsMut, Env, MessageInfo,
-    OverflowError, Response, StdError, StdResult, Uint128, WasmMsg,
+    from_binary, to_binary, Addr, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, OverflowError,
+    Response, StdError, StdResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
-use white_whale::pool_network::asset::{
-    Asset, AssetInfo, AssetInfoRaw, PairInfoRaw, MINIMUM_LIQUIDITY_AMOUNT,
-};
 #[cfg(feature = "token_factory")]
 use cosmwasm_std::coins;
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::asset::is_factory_token;
+use white_whale::pool_network::asset::{
+    Asset, AssetInfo, AssetInfoRaw, PairInfoRaw, MINIMUM_LIQUIDITY_AMOUNT,
+};
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::{Coin, MsgBurn, MsgMint};
 use white_whale::pool_network::pair::{Config, Cw20HookMsg, FeatureToggle, PoolFee};
@@ -302,7 +302,8 @@ pub fn withdraw_liquidity(
 
     let refund_assets = refund_assets?;
 
-    let burn_lp_token_msg = burn_lp_token_msg(liquidity_token, env.contract.address.to_string(), amount)?;
+    let burn_lp_token_msg =
+        burn_lp_token_msg(liquidity_token, env.contract.address.to_string(), amount)?;
 
     // update pool info
     Ok(Response::new()
@@ -604,7 +605,6 @@ fn mint_lp_token_msg(
         funds: vec![],
     })])
 }
-
 
 /// Creates the Burn LP message
 #[allow(unused_variables)]

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply,
-    Response, StdError, StdResult,
+    to_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError,
+    StdResult,
 };
 use cw2::{get_contract_version, set_contract_version};
 use protobuf::Message;
@@ -17,7 +17,8 @@ use crate::error::ContractError;
 use crate::helpers::has_factory_token;
 use crate::response::MsgInstantiateContractResponse;
 use crate::state::{
-    ALL_TIME_BURNED_FEES, ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG, PAIR_INFO,
+    ALL_TIME_BURNED_FEES, ALL_TIME_COLLECTED_PROTOCOL_FEES, COLLECTED_PROTOCOL_FEES, CONFIG,
+    PAIR_INFO,
 };
 use crate::{commands, helpers, queries};
 

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/error.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/error.rs
@@ -72,6 +72,9 @@ pub enum ContractError {
 
     #[error("Burn fee is not allowed when using factory tokens")]
     TokenFactoryAssetBurnDisabled {},
+
+    #[error("The token factory feature is not enabled")]
+    TokenFactoryNotEnabled {},
 }
 
 impl From<semver::Error> for ContractError {

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/helpers.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/helpers.rs
@@ -3,19 +3,19 @@ use std::ops::Mul;
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, Decimal, Decimal256, Deps, DepsMut, Env, ReplyOn, Response, StdError,
-    StdResult, Storage, SubMsg, Uint128, Uint256, WasmMsg,
+    to_binary, Decimal, Decimal256, Deps, DepsMut, Env, ReplyOn, Response, StdError, StdResult,
+    Storage, SubMsg, Uint128, Uint256, WasmMsg,
 };
 use cw20::MinterResponse;
 use cw_storage_plus::Item;
 
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::CosmosMsg;
 use white_whale::pool_network::asset::{
     is_factory_token, Asset, AssetInfo, AssetInfoRaw, PairType,
 };
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgCreateDenom;
-#[cfg(feature = "token_factory")]
-use cosmwasm_std::CosmosMsg;
 use white_whale::pool_network::pair::{InstantiateMsg, PoolFee};
 use white_whale::pool_network::querier::query_token_info;
 use white_whale::pool_network::token::InstantiateMsg as TokenInstantiateMsg;

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/helpers.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/helpers.rs
@@ -2,15 +2,28 @@ use std::cmp::Ordering;
 use std::ops::Mul;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Decimal, Decimal256, Deps, StdError, StdResult, Storage, Uint128, Uint256};
+use cosmwasm_std::{
+    to_binary, Decimal, Decimal256, Deps, DepsMut, Env, ReplyOn, Response, StdError,
+    StdResult, Storage, SubMsg, Uint128, Uint256, WasmMsg,
+};
+use cw20::MinterResponse;
 use cw_storage_plus::Item;
 
-use white_whale::pool_network::asset::{is_factory_token, Asset, AssetInfo, PairType};
-use white_whale::pool_network::pair::PoolFee;
+use white_whale::pool_network::asset::{
+    is_factory_token, Asset, AssetInfo, AssetInfoRaw, PairType,
+};
+#[cfg(feature = "token_factory")]
+use white_whale::pool_network::denom::MsgCreateDenom;
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::CosmosMsg;
+use white_whale::pool_network::pair::{InstantiateMsg, PoolFee};
 use white_whale::pool_network::querier::query_token_info;
+use white_whale::pool_network::token::InstantiateMsg as TokenInstantiateMsg;
 
+use crate::contract::INSTANTIATE_REPLY_ID;
 use crate::error::ContractError;
 use crate::math::Decimal256Helper;
+use crate::state::{LP_SYMBOL, PAIR_INFO};
 
 /// The amount of iterations to perform when calculating the Newton-Raphson approximation.
 const NEWTON_ITERATIONS: u64 = 32;
@@ -471,6 +484,7 @@ pub fn instantiate_fees(
 
 /// Gets the total supply of the given liquidity token
 pub fn get_total_share(deps: &Deps, liquidity_token: String) -> StdResult<Uint128> {
+    #[cfg(feature = "token_factory")]
     let total_share = if is_factory_token(liquidity_token.as_str()) {
         //bank query total
         deps.querier.query_supply(&liquidity_token)?.amount
@@ -481,6 +495,13 @@ pub fn get_total_share(deps: &Deps, liquidity_token: String) -> StdResult<Uint12
         )?
         .total_supply
     };
+    #[cfg(not(feature = "token_factory"))]
+    let total_share = query_token_info(
+        &deps.querier,
+        deps.api.addr_validate(liquidity_token.as_str())?,
+    )?
+    .total_supply;
+
     Ok(total_share)
 }
 
@@ -491,4 +512,58 @@ pub fn has_factory_token(assets: &[AssetInfo]) -> bool {
         AssetInfo::Token { .. } => false,
         AssetInfo::NativeToken { denom } => is_factory_token(denom),
     })
+}
+
+/// Creates a new LP token for this pool
+pub fn create_lp_token(
+    deps: DepsMut,
+    env: &Env,
+    msg: &InstantiateMsg,
+    lp_token_name: &String,
+) -> Result<Response, ContractError> {
+    if msg.token_factory_lp {
+        // create native LP token
+        PAIR_INFO.update(deps.storage, |mut pair_info| -> StdResult<_> {
+            let denom = format!("{}/{}/{}", "factory", env.contract.address, LP_SYMBOL);
+            pair_info.liquidity_token = AssetInfoRaw::NativeToken { denom };
+
+            Ok(pair_info)
+        })?;
+
+        #[cfg(feature = "token_factory")]
+        return Ok(
+            Response::new().add_message(<MsgCreateDenom as Into<CosmosMsg>>::into(
+                MsgCreateDenom {
+                    sender: env.contract.address.to_string(),
+                    subdenom: LP_SYMBOL.to_string(),
+                },
+            )),
+        );
+        #[allow(unreachable_code)]
+        Err(ContractError::TokenFactoryNotEnabled {})
+    } else {
+        Ok(Response::new().add_submessage(SubMsg {
+            // Create LP token
+            msg: WasmMsg::Instantiate {
+                admin: None,
+                code_id: msg.token_code_id,
+                msg: to_binary(&TokenInstantiateMsg {
+                    name: lp_token_name.to_owned(),
+                    symbol: LP_SYMBOL.to_string(),
+                    decimals: 6,
+                    initial_balances: vec![],
+                    mint: Some(MinterResponse {
+                        minter: env.contract.address.to_string(),
+                        cap: None,
+                    }),
+                })?,
+                funds: vec![],
+                label: lp_token_name.to_owned(),
+            }
+            .into(),
+            gas_limit: None,
+            id: INSTANTIATE_REPLY_ID,
+            reply_on: ReplyOn::Success,
+        }))
+    }
 }

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
@@ -1,18 +1,18 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    to_binary,Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg,
-    SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
+    to_binary, Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg, SubMsgResponse,
+    SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::{coin, BankMsg};
 use white_whale::fee::Fee;
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network;
+use white_whale::pool_network::asset::{Asset, AssetInfo, PairType, MINIMUM_LIQUIDITY_AMOUNT};
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgMint;
-#[cfg(feature = "token_factory")]
-use cosmwasm_std::{coin, BankMsg};
-use white_whale::pool_network::asset::{Asset, AssetInfo, PairType, MINIMUM_LIQUIDITY_AMOUNT};
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::pair::{ExecuteMsg, InstantiateMsg, PoolFee};
 

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
@@ -1,14 +1,18 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    coin, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg,
+    to_binary,Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg,
     SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 
 use white_whale::fee::Fee;
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network;
-use white_whale::pool_network::asset::{Asset, AssetInfo, PairType, MINIMUM_LIQUIDITY_AMOUNT};
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgMint;
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::{coin, BankMsg};
+use white_whale::pool_network::asset::{Asset, AssetInfo, PairType, MINIMUM_LIQUIDITY_AMOUNT};
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::pair::{ExecuteMsg, InstantiateMsg, PoolFee};
 
@@ -686,6 +690,7 @@ fn provide_liquidity_invalid_minimum_lp_amount() {
     }
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
 fn provide_liquidity_tokenfactory_lp() {
     let lp_denom = format!("{}/{MOCK_CONTRACT_ADDR}/{LP_SYMBOL}", "factory");

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
@@ -7,6 +7,7 @@ use cw20::MinterResponse;
 
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::{Asset, AssetInfo, PairInfo, PairType};
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgCreateDenom;
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::pair::ExecuteMsg::UpdateConfig;
@@ -121,8 +122,9 @@ fn proper_initialization_cw20_lp() {
     );
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
-fn proper_initialization_tokenfactory_lp() {
+fn proper_initialization_token_factory_lp() {
     let mut deps = mock_dependencies(&[]);
 
     deps.querier.with_token_balances(&[(
@@ -179,6 +181,7 @@ fn proper_initialization_tokenfactory_lp() {
     );
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
 fn intialize_with_burnable_token_factory_asset() {
     let mut deps = mock_dependencies(&[]);

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/withdrawals.rs
@@ -8,6 +8,7 @@ use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use white_whale::fee::Fee;
 use white_whale::pool_network;
 use white_whale::pool_network::asset::{AssetInfo, PairType};
+#[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgBurn;
 use white_whale::pool_network::mock_querier::mock_dependencies;
 use white_whale::pool_network::pair::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, PoolFee};
@@ -460,6 +461,7 @@ fn test_withdrawal_wrong_message() {
     }
 }
 
+#[cfg(feature = "token_factory")]
 #[test]
 fn withdraw_xyk_liquidity_token_factory_lp() {
     let lp_denom = format!("{}/{MOCK_CONTRACT_ADDR}/{LP_SYMBOL}", "factory");
@@ -570,6 +572,8 @@ fn withdraw_xyk_liquidity_token_factory_lp() {
         &attr("refund_assets", "1000uusd, 1000uwhale")
     );
 }
+
+#[cfg(feature = "token_factory")]
 #[test]
 fn withdraw_xyk_liquidity_token_factory_lp_wrong_asset() {
     let lp_denom = format!("{}/{MOCK_CONTRACT_ADDR}/{LP_SYMBOL}", "factory");

--- a/contracts/liquidity_hub/pool-network/terraswap_router/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_router/Cargo.toml
@@ -27,6 +27,8 @@ crate-type = ["cdylib", "rlib"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
+injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 
 [dependencies]
 cw2.workspace = true

--- a/contracts/liquidity_hub/pool-network/terraswap_token/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_token/Cargo.toml
@@ -13,6 +13,8 @@ documentation = "https://docs.cosmwasm.com"
 crate-type = ["cdylib", "rlib"]
 
 [features]
+injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all init/handle/query exports
 library = []

--- a/contracts/liquidity_hub/vault-network/vault/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]

--- a/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_factory/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]

--- a/contracts/liquidity_hub/vault-network/vault_router/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault_router/Cargo.toml
@@ -16,6 +16,8 @@ publish.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
+injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]

--- a/contracts/liquidity_hub/vault-network/vault_router/schema/raw/execute.json
+++ b/contracts/liquidity_hub/vault-network/vault_router/schema/raw/execute.json
@@ -389,43 +389,6 @@
           "additionalProperties": false
         },
         {
-          "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
-          "type": "object",
-          "required": [
-            "stargate"
-          ],
-          "properties": {
-            "stargate": {
-              "type": "object",
-              "required": [
-                "type_url",
-                "value"
-              ],
-              "properties": {
-                "type_url": {
-                  "type": "string"
-                },
-                "value": {
-                  "$ref": "#/definitions/Binary"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "ibc"
-          ],
-          "properties": {
-            "ibc": {
-              "$ref": "#/definitions/IbcMsg"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
           "type": "object",
           "required": [
             "wasm"
@@ -433,18 +396,6 @@
           "properties": {
             "wasm": {
               "$ref": "#/definitions/WasmMsg"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "gov"
-          ],
-          "properties": {
-            "gov": {
-              "$ref": "#/definitions/GovMsg"
             }
           },
           "additionalProperties": false
@@ -503,196 +454,6 @@
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object"
-    },
-    "GovMsg": {
-      "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, vote: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",
-      "oneOf": [
-        {
-          "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
-          "type": "object",
-          "required": [
-            "vote"
-          ],
-          "properties": {
-            "vote": {
-              "type": "object",
-              "required": [
-                "proposal_id",
-                "vote"
-              ],
-              "properties": {
-                "proposal_id": {
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0.0
-                },
-                "vote": {
-                  "description": "The vote option.\n\nThis should be called \"option\" for consistency with Cosmos SDK. Sorry for that. See <https://github.com/CosmWasm/cosmwasm/issues/1571>.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/VoteOption"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "IbcMsg": {
-      "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
-      "oneOf": [
-        {
-          "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
-          "type": "object",
-          "required": [
-            "transfer"
-          ],
-          "properties": {
-            "transfer": {
-              "type": "object",
-              "required": [
-                "amount",
-                "channel_id",
-                "timeout",
-                "to_address"
-              ],
-              "properties": {
-                "amount": {
-                  "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/Coin"
-                    }
-                  ]
-                },
-                "channel_id": {
-                  "description": "exisiting channel to send the tokens over",
-                  "type": "string"
-                },
-                "timeout": {
-                  "description": "when packet times out, measured on remote chain",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/IbcTimeout"
-                    }
-                  ]
-                },
-                "to_address": {
-                  "description": "address on the remote chain to receive these tokens",
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
-          "type": "object",
-          "required": [
-            "send_packet"
-          ],
-          "properties": {
-            "send_packet": {
-              "type": "object",
-              "required": [
-                "channel_id",
-                "data",
-                "timeout"
-              ],
-              "properties": {
-                "channel_id": {
-                  "type": "string"
-                },
-                "data": {
-                  "$ref": "#/definitions/Binary"
-                },
-                "timeout": {
-                  "description": "when packet times out, measured on remote chain",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/IbcTimeout"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
-          "type": "object",
-          "required": [
-            "close_channel"
-          ],
-          "properties": {
-            "close_channel": {
-              "type": "object",
-              "required": [
-                "channel_id"
-              ],
-              "properties": {
-                "channel_id": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "IbcTimeout": {
-      "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
-      "type": "object",
-      "properties": {
-        "block": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/IbcTimeoutBlock"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "timestamp": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Timestamp"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "IbcTimeoutBlock": {
-      "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
-      "type": "object",
-      "required": [
-        "height",
-        "revision"
-      ],
-      "properties": {
-        "height": {
-          "description": "block height after which the packet times out. the height within the given revision",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "revision": {
-          "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        }
-      }
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
@@ -778,30 +539,9 @@
         }
       ]
     },
-    "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Uint64"
-        }
-      ]
-    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
-    },
-    "Uint64": {
-      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
-      "type": "string"
-    },
-    "VoteOption": {
-      "type": "string",
-      "enum": [
-        "yes",
-        "no",
-        "abstain",
-        "no_with_veto"
-      ]
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",

--- a/contracts/liquidity_hub/vault-network/vault_router/schema/vault_router.json
+++ b/contracts/liquidity_hub/vault-network/vault_router/schema/vault_router.json
@@ -414,43 +414,6 @@
             "additionalProperties": false
           },
           {
-            "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
-            "type": "object",
-            "required": [
-              "stargate"
-            ],
-            "properties": {
-              "stargate": {
-                "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
-                "properties": {
-                  "type_url": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "$ref": "#/definitions/Binary"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "ibc"
-            ],
-            "properties": {
-              "ibc": {
-                "$ref": "#/definitions/IbcMsg"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
             "type": "object",
             "required": [
               "wasm"
@@ -458,18 +421,6 @@
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "gov"
-            ],
-            "properties": {
-              "gov": {
-                "$ref": "#/definitions/GovMsg"
               }
             },
             "additionalProperties": false
@@ -528,196 +479,6 @@
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
-      },
-      "GovMsg": {
-        "description": "This message type allows the contract interact with the [x/gov] module in order to cast votes.\n\n[x/gov]: https://github.com/cosmos/cosmos-sdk/tree/v0.45.12/x/gov\n\n## Examples\n\nCast a simple vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); use cosmwasm_std::{GovMsg, VoteOption};\n\n#[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::Vote { proposal_id: 4, vote: VoteOption::Yes, })) } ```\n\nCast a weighted vote:\n\n``` # use cosmwasm_std::{ #     HexBinary, #     Storage, Api, Querier, DepsMut, Deps, entry_point, Env, StdError, MessageInfo, #     Response, QueryResponse, # }; # type ExecuteMsg = (); # #[cfg(feature = \"cosmwasm_1_2\")] use cosmwasm_std::{Decimal, GovMsg, VoteOption, WeightedVoteOption};\n\n# #[cfg(feature = \"cosmwasm_1_2\")] #[entry_point] pub fn execute( deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg, ) -> Result<Response, StdError> { // ... Ok(Response::new().add_message(GovMsg::VoteWeighted { proposal_id: 4, options: vec![ WeightedVoteOption { option: VoteOption::Yes, weight: Decimal::percent(65), }, WeightedVoteOption { option: VoteOption::Abstain, weight: Decimal::percent(35), }, ], })) } ```",
-        "oneOf": [
-          {
-            "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
-            "type": "object",
-            "required": [
-              "vote"
-            ],
-            "properties": {
-              "vote": {
-                "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
-                "properties": {
-                  "proposal_id": {
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "vote": {
-                    "description": "The vote option.\n\nThis should be called \"option\" for consistency with Cosmos SDK. Sorry for that. See <https://github.com/CosmWasm/cosmwasm/issues/1571>.",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/VoteOption"
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "IbcMsg": {
-        "description": "These are messages in the IBC lifecycle. Only usable by IBC-enabled contracts (contracts that directly speak the IBC protocol via 6 entry points)",
-        "oneOf": [
-          {
-            "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
-            "type": "object",
-            "required": [
-              "transfer"
-            ],
-            "properties": {
-              "transfer": {
-                "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
-                "properties": {
-                  "amount": {
-                    "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/Coin"
-                      }
-                    ]
-                  },
-                  "channel_id": {
-                    "description": "exisiting channel to send the tokens over",
-                    "type": "string"
-                  },
-                  "timeout": {
-                    "description": "when packet times out, measured on remote chain",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/IbcTimeout"
-                      }
-                    ]
-                  },
-                  "to_address": {
-                    "description": "address on the remote chain to receive these tokens",
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
-            "type": "object",
-            "required": [
-              "send_packet"
-            ],
-            "properties": {
-              "send_packet": {
-                "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
-                "properties": {
-                  "channel_id": {
-                    "type": "string"
-                  },
-                  "data": {
-                    "$ref": "#/definitions/Binary"
-                  },
-                  "timeout": {
-                    "description": "when packet times out, measured on remote chain",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/IbcTimeout"
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
-            "type": "object",
-            "required": [
-              "close_channel"
-            ],
-            "properties": {
-              "close_channel": {
-                "type": "object",
-                "required": [
-                  "channel_id"
-                ],
-                "properties": {
-                  "channel_id": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "IbcTimeout": {
-        "description": "In IBC each package must set at least one type of timeout: the timestamp or the block height. Using this rather complex enum instead of two timeout fields we ensure that at least one timeout is set.",
-        "type": "object",
-        "properties": {
-          "block": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/IbcTimeoutBlock"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "timestamp": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Timestamp"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        }
-      },
-      "IbcTimeoutBlock": {
-        "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
-        "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
-        "properties": {
-          "height": {
-            "description": "block height after which the packet times out. the height within the given revision",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "revision": {
-            "description": "the version that the client is currently on (eg. after reseting the chain this could increment 1 as height drops to 0)",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        }
       },
       "StakingMsg": {
         "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
@@ -803,30 +564,9 @@
           }
         ]
       },
-      "Timestamp": {
-        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
-        "allOf": [
-          {
-            "$ref": "#/definitions/Uint64"
-          }
-        ]
-      },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
         "type": "string"
-      },
-      "Uint64": {
-        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
-        "type": "string"
-      },
-      "VoteOption": {
-        "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",

--- a/contracts/liquidity_hub/whale_lair/Cargo.toml
+++ b/contracts/liquidity_hub/whale_lair/Cargo.toml
@@ -22,6 +22,8 @@ exclude = [
 crate-type = ["cdylib", "rlib"]
 
 [features]
+injective = ["white-whale/injective"]
+token_factory = ["white-whale/token_factory"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 

--- a/packages/white-whale/Cargo.toml
+++ b/packages/white-whale/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "white-whale"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 description = "Common White Whale types and utils"
@@ -16,6 +16,7 @@ documentation = "https://whitewhale.money"
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 injective = []
+token_factory = ["cosmwasm-std/stargate", "cosmwasm-std/cosmwasm_1_1"]
 
 [dependencies]
 cosmwasm-std.workspace = true

--- a/packages/white-whale/src/pool_network/mod.rs
+++ b/packages/white-whale/src/pool_network/mod.rs
@@ -1,4 +1,5 @@
 pub mod asset;
+#[cfg(feature = "token_factory")]
 pub mod denom;
 pub mod factory;
 pub mod pair;

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -7,7 +7,7 @@ projectRootPath=$(realpath "$0" | sed 's|\(.*\)/.*|\1|' | cd ../ | pwd)
 docker run --rm -v "$projectRootPath":/code \
   --mount type=volume,source="$(basename "$projectRootPath")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.10
+  cosmwasm/workspace-optimizer:0.12.13
 
 # Check generated wasm file sizes
 $projectRootPath/scripts/check_artifacts_size.sh


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR makes the `cosmwasm_1_1` feature to be optional, together with `stargate` , that are being used with the token factory things.

This way we can still deploy contracts on those blockchains that don't support comswasm 1.1/token factory yet.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
