### PR TITLE
fix(3pool): Fix broken test on main

### DIFF
--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
     SubMsgResult, Uint128, WasmMsg,
 };
 #[cfg(feature = "token_factory")]
-use cosmwasm_std::{coin, BankMsg};
+use cosmwasm_std::{coin};
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::AssetInfo;

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
@@ -5,8 +5,8 @@ use crate::state::LP_SYMBOL;
 use crate::state::{get_fees_for_asset, store_fee, COLLECTED_PROTOCOL_FEES};
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    attr, to_binary, Coin, CosmosMsg, Decimal, Reply, SubMsg, SubMsgResponse, SubMsgResult,
-    Uint128, WasmMsg,
+    attr, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, SubMsg, SubMsgResponse,
+    SubMsgResult, Uint128, WasmMsg,
 };
 #[cfg(feature = "token_factory")]
 use cosmwasm_std::{coin, BankMsg};

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/tests/withdrawals.rs
@@ -3,13 +3,13 @@ use crate::error::ContractError;
 #[cfg(feature = "token_factory")]
 use crate::state::LP_SYMBOL;
 use crate::state::{get_fees_for_asset, store_fee, COLLECTED_PROTOCOL_FEES};
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::coin;
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     attr, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, SubMsg, SubMsgResponse,
     SubMsgResult, Uint128, WasmMsg,
 };
-#[cfg(feature = "token_factory")]
-use cosmwasm_std::{coin};
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::AssetInfo;

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
@@ -1,13 +1,14 @@
+use crate::state::LP_SYMBOL;
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
+#[cfg(feature = "token_factory")]
+use cosmwasm_std::{coin, BankMsg};
 use cosmwasm_std::{
     to_binary, Coin, CosmosMsg, Decimal, Reply, Response, StdError, SubMsg, SubMsgResponse,
     SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
-
-#[cfg(feature = "token_factory")]
-use cosmwasm_std::{coin, BankMsg};
 use white_whale::fee::Fee;
+
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network;
 use white_whale::pool_network::asset::{Asset, AssetInfo, PairType, MINIMUM_LIQUIDITY_AMOUNT};

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/provide_liquidity.rs
@@ -18,7 +18,6 @@ use white_whale::pool_network::pair::{ExecuteMsg, InstantiateMsg, PoolFee};
 
 use crate::contract::{execute, instantiate, reply};
 use crate::error::ContractError;
-use crate::state::LP_SYMBOL;
 
 #[test]
 fn provide_liquidity_cw20_lp() {

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, CosmosMsg, Decimal, Reply, ReplyOn, StdError, SubMsg,
-    SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
+    from_binary, to_binary, Addr, Decimal, Reply, ReplyOn, StdError, SubMsg, SubMsgResponse,
+    SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::MinterResponse;
 
@@ -18,7 +18,6 @@ use crate::contract::{execute, instantiate, migrate, query, reply};
 use crate::error::ContractError;
 use crate::helpers::{assert_max_spread, assert_slippage_tolerance};
 use crate::queries::query_pair_info;
-use crate::state::LP_SYMBOL;
 
 #[test]
 fn proper_initialization_cw20_lp() {

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/testing.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "token_factory")]
+use crate::state::LP_SYMBOL;
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, Decimal, Reply, ReplyOn, StdError, SubMsg, SubMsgResponse,
-    SubMsgResult, Uint128, WasmMsg,
+    from_binary, to_binary, Addr, CosmosMsg, Decimal, Reply, ReplyOn, StdError, SubMsg,
+    SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::MinterResponse;
-
 use white_whale::fee::Fee;
 use white_whale::pool_network::asset::{Asset, AssetInfo, PairInfo, PairType};
 #[cfg(feature = "token_factory")]

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/withdrawals.rs
@@ -1,11 +1,15 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    attr, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, Response, SubMsg, SubMsgResponse,
-    SubMsgResult, Uint128, WasmMsg,
+    attr, coin, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, Response, SubMsg,
+    SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
+#[cfg(feature = "token_factory")]
+use crate::state::LP_SYMBOL;
 use white_whale::fee::Fee;
+#[cfg(feature = "token_factory")]
+use white_whale::pool_network;
 use white_whale::pool_network::asset::{AssetInfo, PairType};
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgBurn;

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/withdrawals.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/tests/withdrawals.rs
@@ -1,12 +1,11 @@
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    attr, coin, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, Response, SubMsg,
-    SubMsgResponse, SubMsgResult, Uint128, WasmMsg,
+    attr, to_binary, BankMsg, Coin, CosmosMsg, Decimal, Reply, Response, SubMsg, SubMsgResponse,
+    SubMsgResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 
 use white_whale::fee::Fee;
-use white_whale::pool_network;
 use white_whale::pool_network::asset::{AssetInfo, PairType};
 #[cfg(feature = "token_factory")]
 use white_whale::pool_network::denom::MsgBurn;
@@ -15,7 +14,6 @@ use white_whale::pool_network::pair::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, P
 
 use crate::contract::{execute, instantiate, reply};
 use crate::error::ContractError;
-use crate::state::LP_SYMBOL;
 use crate::state::{get_fees_for_asset, store_fee, COLLECTED_PROTOCOL_FEES};
 
 #[test]


### PR DESCRIPTION
It was just a missing import? Also clean up lints in pool-network while at it

Seen this coming up in my console while refactoring bonding, did as a separate PR. 

- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [X] The code is formatted properly `cargo fmt --all --`.
- [X] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [X] I have regenerated the schemas if needed `cargo schema`.
