### PR TITLE
chore: add fee distributor address to update_config message on incetive factory

### DIFF
--- a/contracts/liquidity_hub/pool-network/incentive_factory/schema/incentive-factory.json
+++ b/contracts/liquidity_hub/pool-network/incentive_factory/schema/incentive-factory.json
@@ -189,6 +189,13 @@
                   "null"
                 ]
               },
+              "fee_distributor_addr": {
+                "description": "The new fee distributor address to get epochs from.\n\nIf unspecified, the fee distributor address will not change.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "incentive_code_id": {
                 "description": "The new code ID of the incentive contract.\n\nIf unspecified, the incentive contract id will not change.",
                 "type": [

--- a/contracts/liquidity_hub/pool-network/incentive_factory/schema/raw/execute.json
+++ b/contracts/liquidity_hub/pool-network/incentive_factory/schema/raw/execute.json
@@ -52,6 +52,13 @@
                 "null"
               ]
             },
+            "fee_distributor_addr": {
+              "description": "The new fee distributor address to get epochs from.\n\nIf unspecified, the fee distributor address will not change.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "incentive_code_id": {
               "description": "The new code ID of the incentive contract.\n\nIf unspecified, the incentive contract id will not change.",
               "type": [

--- a/contracts/liquidity_hub/pool-network/incentive_factory/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/incentive_factory/src/contract.rs
@@ -102,6 +102,7 @@ pub fn execute(
         ExecuteMsg::UpdateConfig {
             owner,
             fee_collector_addr,
+            fee_distributor_addr,
             create_flow_fee,
             max_concurrent_flows,
             incentive_code_id: incentive_contract_id,
@@ -112,6 +113,7 @@ pub fn execute(
             deps,
             owner,
             fee_collector_addr,
+            fee_distributor_addr,
             create_flow_fee,
             max_concurrent_flows,
             incentive_contract_id,

--- a/contracts/liquidity_hub/pool-network/incentive_factory/src/execute/update_config.rs
+++ b/contracts/liquidity_hub/pool-network/incentive_factory/src/execute/update_config.rs
@@ -8,6 +8,7 @@ pub fn update_config(
     deps: DepsMut,
     owner: Option<String>,
     fee_collector_addr: Option<String>,
+    fee_distributor_addr: Option<String>,
     create_flow_fee: Option<Asset>,
     max_concurrent_flows: Option<u64>,
     incentive_contract_id: Option<u64>,
@@ -23,6 +24,10 @@ pub fn update_config(
 
     if let Some(fee_collector_addr) = fee_collector_addr {
         config.fee_collector_addr = deps.api.addr_validate(&fee_collector_addr)?;
+    }
+
+    if let Some(fee_distributor_addr) = fee_distributor_addr {
+        config.fee_distributor_addr = deps.api.addr_validate(&fee_distributor_addr)?;
     }
 
     if let Some(create_flow_fee) = create_flow_fee {
@@ -73,6 +78,10 @@ pub fn update_config(
         ("action", "update_config".to_string()),
         ("owner", config.owner.to_string()),
         ("fee_collector_addr", config.fee_collector_addr.to_string()),
+        (
+            "fee_distributor_addr",
+            config.fee_distributor_addr.to_string(),
+        ),
         ("create_flow_fee", config.create_flow_fee.to_string()),
         (
             "max_concurrent_flows",
@@ -154,6 +163,7 @@ mod tests {
         let msg = UpdateConfig {
             owner: Some("new_owner".to_string()),
             fee_collector_addr: Some("new_fee_collector_addr".to_string()),
+            fee_distributor_addr: Some("new_fee_distributor_addr".to_string()),
             create_flow_fee: Some(Asset {
                 info: AssetInfo::NativeToken {
                     denom: "uwhale".to_string(),
@@ -178,7 +188,7 @@ mod tests {
             Config {
                 owner: Addr::unchecked("new_owner"),
                 fee_collector_addr: Addr::unchecked("new_fee_collector_addr"),
-                fee_distributor_addr: Addr::unchecked("fee_distributor_addr"),
+                fee_distributor_addr: Addr::unchecked("new_fee_distributor_addr"),
                 create_flow_fee: Asset {
                     info: AssetInfo::NativeToken {
                         denom: "uwhale".to_string()
@@ -220,6 +230,7 @@ mod tests {
         let msg = UpdateConfig {
             owner: None,
             fee_collector_addr: None,
+            fee_distributor_addr: None,
             create_flow_fee: None,
             max_concurrent_flows: Some(0u64),
             incentive_code_id: None,
@@ -245,6 +256,7 @@ mod tests {
         let msg = UpdateConfig {
             owner: None,
             fee_collector_addr: None,
+            fee_distributor_addr: None,
             create_flow_fee: None,
             max_concurrent_flows: None,
             incentive_code_id: None,
@@ -262,6 +274,7 @@ mod tests {
         let msg = UpdateConfig {
             owner: None,
             fee_collector_addr: None,
+            fee_distributor_addr: None,
             create_flow_fee: None,
             max_concurrent_flows: None,
             incentive_code_id: None,

--- a/packages/white-whale/src/pool_network/incentive_factory.rs
+++ b/packages/white-whale/src/pool_network/incentive_factory.rs
@@ -41,6 +41,10 @@ pub enum ExecuteMsg {
         ///
         /// If unspecified, the fee collector address will not change.
         fee_collector_addr: Option<String>,
+        /// The new fee distributor address to get epochs from.
+        ///
+        /// If unspecified, the fee distributor address will not change.
+        fee_distributor_addr: Option<String>,
         /// The new fee that must be paid to create a flow.
         ///
         /// If unspecified, the flow fee will not change.


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This adds the possibility to change the fee distributor address on the incentive factory.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
