### PR TITLE
fix(incentive): fix bug when opening positions with an optional receiver

### DIFF
--- a/contracts/liquidity_hub/pool-network/incentive/src/execute/expand_position.rs
+++ b/contracts/liquidity_hub/pool-network/incentive/src/execute/expand_position.rs
@@ -41,7 +41,7 @@ pub fn expand_position(
             funds: info.funds.clone(),
             sender: receiver,
         })
-        .unwrap_or(info);
+        .unwrap_or_else(|| info.clone());
 
     // increase position
     OPEN_POSITIONS.update::<_, ContractError>(

--- a/contracts/liquidity_hub/pool-network/incentive/src/execute/open_position.rs
+++ b/contracts/liquidity_hub/pool-network/incentive/src/execute/open_position.rs
@@ -88,16 +88,16 @@ pub fn open_position(
     })?;
 
     let mut user_weight = ADDRESS_WEIGHT
-        .may_load(deps.storage, info.sender.clone())?
+        .may_load(deps.storage, receiver.sender.clone())?
         .unwrap_or_default();
     user_weight = user_weight.checked_add(weight)?;
-    ADDRESS_WEIGHT.save(deps.storage, info.sender.clone(), &user_weight)?;
+    ADDRESS_WEIGHT.save(deps.storage, receiver.sender.clone(), &user_weight)?;
 
     let current_epoch = helpers::get_current_epoch(deps.as_ref())?;
 
     ADDRESS_WEIGHT_HISTORY.update::<_, StdError>(
         deps.storage,
-        (&info.sender, current_epoch + 1u64),
+        (&receiver.sender, current_epoch + 1u64),
         |_| Ok(user_weight),
     )?;
 


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR fixes the case when we open a flow position with an optional receiver. This is the case when using the frontend helper contract.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
