### PR TITLE
Feat/check contract names on migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ version = "1.1.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw2 0.15.1",
  "cw20",
  "osmosis-std-derive",
  "prost 0.11.9",

--- a/contracts/liquidity_hub/fee_collector/src/contract.rs
+++ b/contracts/liquidity_hub/fee_collector/src/contract.rs
@@ -154,6 +154,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 #[cfg(not(tarpaulin_include))]
 #[entry_point]
 pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    use white_whale::migrate_guards::check_contract_name;
+
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 
@@ -163,6 +165,8 @@ pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Respons
             new_version: version,
         });
     }
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
 
     if storage_version <= Version::parse("1.0.5")? {
         migrations::migrate_to_v110(deps.branch())?;

--- a/contracts/liquidity_hub/fee_collector/src/tests/testing.rs
+++ b/contracts/liquidity_hub/fee_collector/src/tests/testing.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{from_binary, Addr, DepsMut, MessageInfo, Response};
-use cw2::{get_contract_version, ContractVersion};
+use cw2::{get_contract_version, set_contract_version, ContractVersion};
 use std::env;
 use white_whale::pool_network::asset::AssetInfo;
 
@@ -127,6 +127,26 @@ fn test_migration() {
     match res {
         Err(ContractError::MigrateInvalidVersion { .. }) => (),
         _ => panic!("should return ContractError::MigrateInvalidVersion"),
+    }
+
+    set_contract_version(
+        &mut deps.storage,
+        "notWW-fee_collector".to_string(),
+        "1.0.0",
+    )
+    .unwrap();
+
+    let res = migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+    // should not be able to migrate as the contract name is different Should be a StdError Contract name mismatch
+    match res {
+        Err(ContractError::Std { .. }) => {
+            // Match the error message Contract name mismatch
+            assert_eq!(
+                res.unwrap_err().to_string(),
+                "Generic error: Contract name mismatch".to_string()
+            );
+        }
+        _ => panic!("should return ContractError::Std"),
     }
 }
 

--- a/contracts/liquidity_hub/fee_distributor/src/contract.rs
+++ b/contracts/liquidity_hub/fee_distributor/src/contract.rs
@@ -155,6 +155,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 #[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    use white_whale::migrate_guards::check_contract_name;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 

--- a/contracts/liquidity_hub/pool-network/stableswap_3pool/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/stableswap_3pool/src/contract.rs
@@ -279,6 +279,10 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
 #[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    use white_whale::migrate_guards::check_contract_name;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
+
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
@@ -242,7 +242,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 #[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    use white_whale::migrate_guards::check_contract_name;
+
     use crate::migrations;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
 
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/contract.rs
@@ -233,7 +233,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
 #[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    use white_whale::migrate_guards::check_contract_name;
+
     use crate::migrations;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
 
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;

--- a/contracts/liquidity_hub/pool-network/terraswap_router/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_router/src/contract.rs
@@ -509,6 +509,10 @@ fn test_invalid_operations() {
 #[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    use white_whale::migrate_guards::check_contract_name;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
+
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 

--- a/contracts/liquidity_hub/vault-network/vault/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault/src/contract.rs
@@ -147,7 +147,11 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, VaultError> {
     // initialize the loan counter
+
+    use white_whale::migrate_guards::check_contract_name;
     LOAN_COUNTER.save(deps.storage, &0)?;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
 
     let version: Version = CONTRACT_VERSION
         .parse()

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
@@ -67,6 +67,10 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
 #[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    use white_whale::migrate_guards::check_contract_name;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
+
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 

--- a/contracts/liquidity_hub/vault-network/vault_router/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault_router/src/contract.rs
@@ -67,6 +67,10 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
 #[cfg(not(tarpaulin_include))]
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    use white_whale::migrate_guards::check_contract_name;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
+
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 

--- a/contracts/liquidity_hub/whale_lair/src/contract.rs
+++ b/contracts/liquidity_hub/whale_lair/src/contract.rs
@@ -119,6 +119,10 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 #[cfg(not(tarpaulin_include))]
 #[entry_point]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    use white_whale::migrate_guards::check_contract_name;
+
+    check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
+
     let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 

--- a/packages/white-whale/Cargo.toml
+++ b/packages/white-whale/Cargo.toml
@@ -24,6 +24,7 @@ schemars.workspace = true
 serde.workspace = true
 cosmwasm-schema.workspace = true
 cw20.workspace = true
+cw2.workspace = true
 protobuf.workspace = true
 uint.workspace = true
 osmosis-std-derive.workspace = true

--- a/packages/white-whale/src/lib.rs
+++ b/packages/white-whale/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod fee;
 pub mod fee_collector;
 pub mod fee_distributor;
+pub mod migrate_guards;
 pub mod pool_network;
 pub mod vault_network;
 pub mod whale_lair;

--- a/packages/white-whale/src/migrate_guards.rs
+++ b/packages/white-whale/src/migrate_guards.rs
@@ -2,10 +2,9 @@ use cosmwasm_std::{StdError, Storage};
 use cw2::CONTRACT;
 
 pub fn check_contract_name(store: &dyn Storage, new_name: String) -> Result<(), StdError> {
-    let contract_name = new_name.to_string();
     let stored_contract_name = CONTRACT.load(store)?.contract;
     // Prevent accidentally migrating to a different contract
-    if stored_contract_name != contract_name {
+    if stored_contract_name != new_name {
         return Err(StdError::generic_err("Contract name mismatch"));
     }
     Ok(())

--- a/packages/white-whale/src/migrate_guards.rs
+++ b/packages/white-whale/src/migrate_guards.rs
@@ -1,0 +1,12 @@
+use cosmwasm_std::{StdError, Storage};
+use cw2::CONTRACT;
+
+pub fn check_contract_name(store: &dyn Storage, new_name: String) -> Result<(), StdError> {
+    let contract_name = new_name.to_string();
+    let stored_contract_name = CONTRACT.load(store)?.contract;
+    // Prevent accidentally migrating to a different contract
+    if stored_contract_name != contract_name {
+        return Err(StdError::generic_err("Contract name mismatch"));
+    }
+    Ok(())
+}


### PR DESCRIPTION
Added a small function in the ww package which is a Migrate `guard`. 
Guards (Gardai) are very efficient when we want to simply check some things before we do operation

More on [Guards](https://en.wikipedia.org/wiki/Guard_(computer_science)#:~:text=In%20computer%20programming%2C%20a%20guard,in%20the%20branch%20in%20question.)

Updated 1 test to confirm this new behaviour. 