### PR TITLE
fix: fix faulty epochs created prior v0.9.0 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "fee_distributor"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/fee_distributor/Cargo.toml
+++ b/contracts/liquidity_hub/fee_distributor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fee_distributor"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "Contract to distribute the fees collected by the Fee Collector."

--- a/contracts/liquidity_hub/fee_distributor/src/contract.rs
+++ b/contracts/liquidity_hub/fee_distributor/src/contract.rs
@@ -180,10 +180,18 @@ pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Respons
         });
     }
 
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     if storage_version < Version::parse("0.9.0")? {
         migrations::migrate_to_v090(deps.branch())?;
     }
 
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    if storage_version == Version::parse("0.9.0")? {
+        let fees_refund_messages = migrations::migrate_to_v091(deps.branch())?;
+        return Ok(Response::default()
+            .add_messages(fees_refund_messages)
+            .add_attribute("action", "migrate"));
+    }
+
     Ok(Response::default())
 }

--- a/contracts/liquidity_hub/fee_distributor/src/migrations.rs
+++ b/contracts/liquidity_hub/fee_distributor/src/migrations.rs
@@ -1,14 +1,19 @@
 #![cfg(not(tarpaulin_include))]
-use crate::state::{CONFIG, EPOCHS};
+
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    to_binary, DepsMut, Order, QueryRequest, StdError, StdResult, Timestamp, Uint64, WasmQuery,
+    to_binary, CosmosMsg, DepsMut, Order, QueryRequest, StdError, StdResult, Timestamp,
+    Uint64, WasmQuery,
 };
 use cw_storage_plus::Map;
+
 use white_whale::fee_distributor::Epoch;
+use white_whale::pool_network::asset;
 use white_whale::pool_network::asset::Asset;
 use white_whale::whale_lair::GlobalIndex;
 use white_whale::whale_lair::QueryMsg as LairQueryMsg;
+
+use crate::state::{get_claimable_epochs, CONFIG, EPOCHS};
 
 /// Migrates state from the first iteration, v0.8.* to v0.9.0, which includes the global index in
 /// the Epoch. This was done to fix bonding issues.
@@ -60,4 +65,42 @@ pub fn migrate_to_v090(deps: DepsMut) -> Result<(), StdError> {
     }
 
     Ok(())
+}
+
+/// Fixes the broken state for Epochs created prior to the v0.9.0 migration.
+pub fn migrate_to_v091(deps: DepsMut) -> Result<Vec<CosmosMsg>, StdError> {
+    let claimable_epochs = get_claimable_epochs(deps.as_ref())?;
+
+    // 14 June 2023 16:00:00 UTC
+    let migration_timestamp = Timestamp::from_seconds(1686758400);
+    let mut faulty_epochs = claimable_epochs
+        .epochs
+        .into_iter()
+        .filter(|epoch| epoch.start_time.seconds() < migration_timestamp.seconds())
+        .collect::<Vec<Epoch>>();
+
+    let fee_collector_addr = CONFIG.load(deps.storage)?.fee_collector_addr;
+
+    // collect all available funds on faulty epochs and send them back to the fee collector, to be
+    // redistributed on the next (new) epoch
+
+    let mut total_fees: Vec<Asset> = vec![];
+    for epoch in faulty_epochs.iter_mut() {
+        total_fees = asset::aggregate_assets(total_fees, epoch.available.clone())?;
+
+        // set the available fees of this faulty epoch to zero
+        epoch.available = vec![];
+
+        // save the faulty epoch in the state
+        EPOCHS.save(deps.storage, &epoch.id.to_be_bytes(), &epoch)?;
+    }
+
+    // create messages to send total_fees back to the fee collector
+    let mut messages = vec![];
+
+    for fee in total_fees {
+        messages.push(fee.into_msg(fee_collector_addr.clone())?);
+    }
+
+    Ok(messages)
 }


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR fixes the faulty epochs on the terra mainnet caused when migrating the fee distributor contract to v0.9.0.

The issue was caused by a query that would give an error when calculating the weight due to the global index set to all epochs on migration v0.9.0.

V0.9.1 makes all the available rewards for epochs prior to the migration, sets them to zero, and sends these tokens to the fee collector, to be redistributed on the next epoch.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
