### PR TITLE
fix: prevent users from bonding/unbonding if the latest epoch has not been created

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,7 +1657,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whale-lair"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/liquidity_hub/whale_lair/Cargo.toml
+++ b/contracts/liquidity_hub/whale_lair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whale-lair"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "The Whale Lair is a bonding contract used to bond WHALE LSDs."

--- a/contracts/liquidity_hub/whale_lair/src/contract.rs
+++ b/contracts/liquidity_hub/whale_lair/src/contract.rs
@@ -75,8 +75,8 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::Bond { asset } => commands::bond(deps, env.block.time, info, asset),
-        ExecuteMsg::Unbond { asset } => commands::unbond(deps, env.block.time, info, asset),
+        ExecuteMsg::Bond { asset } => commands::bond(deps, env.block.time, info, env, asset),
+        ExecuteMsg::Unbond { asset } => commands::unbond(deps, env.block.time, info, env, asset),
         ExecuteMsg::Withdraw { denom } => {
             commands::withdraw(deps, env.block.time, info.sender, denom)
         }

--- a/contracts/liquidity_hub/whale_lair/src/error.rs
+++ b/contracts/liquidity_hub/whale_lair/src/error.rs
@@ -53,6 +53,9 @@ pub enum ContractError {
 
     #[error("There are unclaimed rewards available. Claim them before attempting to bond/unbond")]
     UnclaimedRewards {},
+
+    #[error("Trying to bond/unbond at a late time before the new/latest epoch has been created")]
+    NewEpochNotCreatedYet {},
 }
 
 impl From<semver::Error> for ContractError {

--- a/contracts/liquidity_hub/whale_lair/src/helpers.rs
+++ b/contracts/liquidity_hub/whale_lair/src/helpers.rs
@@ -1,5 +1,5 @@
-use cosmwasm_std::{Decimal, DepsMut, MessageInfo, StdResult, Timestamp, Uint64};
-use white_whale::fee_distributor::{ClaimableEpochsResponse, EpochConfig};
+use cosmwasm_std::{Decimal, DepsMut, Env, MessageInfo, StdResult, Timestamp, Uint64};
+use white_whale::fee_distributor::{ClaimableEpochsResponse, EpochConfig, EpochResponse};
 use white_whale::pool_network::asset::{Asset, AssetInfo};
 
 use crate::error::ContractError;
@@ -48,19 +48,44 @@ pub fn validate_claimed(deps: &DepsMut, info: &MessageInfo) -> Result<(), Contra
     let fee_distributor = config.fee_distributor_addr;
 
     // Do a smart query for Claimable
-    let claimable_rewards: ClaimableEpochsResponse = deps
-        .querier
-        .query_wasm_smart(
-            fee_distributor,
-            &white_whale::fee_distributor::QueryMsg::Claimable {
-                address: info.sender.to_string(),
-            },
-        )
-        .unwrap();
+    let claimable_rewards: ClaimableEpochsResponse = deps.querier.query_wasm_smart(
+        fee_distributor,
+        &white_whale::fee_distributor::QueryMsg::Claimable {
+            address: info.sender.to_string(),
+        },
+    )?;
 
     // If epochs is greater than none
     if !claimable_rewards.epochs.is_empty() {
         return Err(ContractError::UnclaimedRewards {});
+    }
+
+    Ok(())
+}
+
+/// Validates that the current time is not more than a day after the epoch start time. Helps preventing
+/// global_index timestamp issues when querying the weight.
+pub fn validate_bonding_for_current_epoch(deps: &DepsMut, env: &Env) -> Result<(), ContractError> {
+    // Query current epoch on fee distributor
+    let config = CONFIG.load(deps.storage)?;
+    let fee_distributor = config.fee_distributor_addr;
+
+    let epoch_response: EpochResponse = deps.querier.query_wasm_smart(
+        fee_distributor,
+        &white_whale::fee_distributor::QueryMsg::CurrentEpoch {},
+    )?;
+
+    let current_epoch = epoch_response.epoch;
+    let current_time = env.block.time.seconds();
+    pub const DAY_IN_SECONDS: u64 = 86_400u64;
+
+    // if the current time is more than a day after the epoch start time, then it means the latest
+    // epoch has not been created and thus, prevent users from bonding/unbonding to avoid global_index
+    // timestamp issues when querying the weight.
+    if current_epoch.id != Uint64::zero()
+        && current_time - current_epoch.start_time.seconds() > DAY_IN_SECONDS
+    {
+        return Err(ContractError::NewEpochNotCreatedYet {});
     }
 
     Ok(())


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR prevents users from bonding/unbonding if the latest epoch has not been created yet after it was supposed to be created. That fixes potential issues with global index snapshots.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
