### PR TITLE
fix: add missing funds to create_vault message so the tf denom can be created

### DIFF
--- a/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/contract.rs
@@ -50,7 +50,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             asset_info,
             fees,
             token_factory_lp,
-        } => create_vault(deps, env, asset_info, fees, token_factory_lp),
+        } => create_vault(deps, env, info, asset_info, fees, token_factory_lp),
         ExecuteMsg::UpdateVaultConfig { vault_addr, params } => {
             update_vault_config(deps, vault_addr, params)
         }

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg};
+use cosmwasm_std::{to_binary, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg, MessageInfo};
 use white_whale::fee::VaultFee;
 use white_whale::pool_network::asset::AssetInfo;
 use white_whale::vault_network::vault::InstantiateMsg;
@@ -13,6 +13,7 @@ use crate::{
 pub fn create_vault(
     deps: DepsMut,
     env: Env,
+    info: MessageInfo,
     asset_info: AssetInfo,
     fees: VaultFee,
     token_factory_lp: bool,
@@ -44,7 +45,7 @@ pub fn create_vault(
                 vault_fees: fees,
                 token_factory_lp,
             })?,
-            funds: vec![],
+            funds: info.funds,
             label: format!(
                 "White Whale {} Vault",
                 asset_info.clone().get_label(&deps.as_ref())?


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This fixes missing funds being passed to the vault when using the token factory to create the lp denom.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
