### PR TITLE
fix: prevent incentives script to stop if an incentive contract for a…

### DIFF
--- a/scripts/deployment/create_incentives.sh
+++ b/scripts/deployment/create_incentives.sh
@@ -50,8 +50,10 @@ function create_incentives() {
 
     incentive_contract=$($BINARY tx wasm execute $incentive_factory_addr "$MSG" $TXFLAG --from $deployer_address | jq -r '.logs[].events[] | select(.type == "instantiate") | .attributes[] | select(.key == "_contract_address") | .value')
 
-    # Append incentive_contract to output file
-    append_incentive_contract_to_output $pool $(echo "$pool_label" | sed 's/ pair//') $incentive_contract
+    if [ -n "$incentive_contract" ]; then
+      # Append incentive_contract to output file
+      append_incentive_contract_to_output $pool $(echo "$pool_label" | sed 's/ pair//') $incentive_contract
+    fi
 
     sleep $tx_delay
   done

--- a/scripts/deployment/deploy_env/base_migaloo.env
+++ b/scripts/deployment/deploy_env/base_migaloo.env
@@ -1,0 +1,1 @@
+export TXFLAG="--node $RPC --chain-id $CHAIN_ID --gas-prices 0.25$DENOM --gas auto --gas-adjustment 1.3 -y -b block --output json"

--- a/scripts/deployment/deploy_env/chain_env.sh
+++ b/scripts/deployment/deploy_env/chain_env.sh
@@ -71,10 +71,12 @@ function init_chain_env() {
 
   migaloo)
     source <(cat "$project_root_path"/scripts/deployment/deploy_env/mainnets/migaloo.env)
+    source <(cat "$project_root_path"/scripts/deployment/deploy_env/base_migaloo.env)
     ;;
 
   migaloo-testnet)
     source <(cat "$project_root_path"/scripts/deployment/deploy_env/testnets/migaloo.env)
+    source <(cat "$project_root_path"/scripts/deployment/deploy_env/base_migaloo.env)
     ;;
 
   orai)
@@ -87,7 +89,7 @@ function init_chain_env() {
     ;;
   esac
 
-  if [[ $chain != "chihuahua" && $chain != "injective" && $chain != "injective-testnet" ]]; then
+  if [[ $chain != "chihuahua" && $chain != "injective" && $chain != "injective-testnet" && $chain != "migaloo" && $chain != "migaloo-testnet" ]]; then
     source <(cat "$project_root_path"/scripts/deployment/deploy_env/base.env)
   fi
 }


### PR DESCRIPTION
… given lp has already been deployed

## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

The script for creating incentive contracts would fail if an incentive for a given LP had already been deployed. This PR fixes this.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
