### PR TITLE
fix(incentive): filter zero rewards from query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "incentive"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/liquidity_hub/pool-network/incentive/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/incentive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incentive"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
 edition.workspace = true
 description = "An incentive manager for an LP token"

--- a/contracts/liquidity_hub/pool-network/incentive/src/queries/get_rewards.rs
+++ b/contracts/liquidity_hub/pool-network/incentive/src/queries/get_rewards.rs
@@ -163,5 +163,7 @@ pub fn get_rewards(deps: Deps, address: String) -> Result<RewardsResponse, Contr
         });
     }
 
+    rewards.retain(|asset| asset.amount > Uint128::zero());
+
     Ok(RewardsResponse { rewards })
 }

--- a/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
+++ b/contracts/liquidity_hub/vault-network/vault_factory/src/execute/create_vault.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, DepsMut, Env, ReplyOn, Response, SubMsg, WasmMsg, MessageInfo};
+use cosmwasm_std::{to_binary, DepsMut, Env, MessageInfo, ReplyOn, Response, SubMsg, WasmMsg};
 use white_whale::fee::VaultFee;
 use white_whale::pool_network::asset::AssetInfo;
 use white_whale::vault_network::vault::InstantiateMsg;


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR improves the incentive rewards query by filtering the zero amount rewards. Instead, it returns an empty vector. 

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

#212 

---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
