### PR TITLE
ci: add script to migrate incentives

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,6 +1,53 @@
 #!/bin/bash
 set -e
 
+# Displays tool usage
+function display_usage() {
+  echo "Release builder"
+  echo -e "\nUsage:./build_release.sh [flags].\n"
+  echo -e "Available flags:\n"
+  echo -e "  -c \tThe chain where you want to deploy (migaloo|juno|terra|...)"
+}
+
+if [ -z $1 ]; then
+  display_usage
+  exit 0
+fi
+
+while getopts ":c:" opt; do
+  case $opt in
+  c)
+    chain="$OPTARG"
+    ;;
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    display_usage
+    exit 1
+    ;;
+  esac
+done
+
+flag=""
+
+case $chain in
+
+juno)
+  flag="-osmosis_token_factory"
+  ;;
+terra | migaloo)
+  flag="-token_factory"
+  ;;
+injective)
+  flag="-injective"
+  ;;
+chihuahua | comdex | orai) ;;
+
+\*)
+  echo "Network $chain not defined"
+  exit 1
+  ;;
+esac
+
 projectRootPath=$(realpath "$0" | sed 's|\(.*\)/.*|\1|' | cd ../ | pwd)
 
 # if the operative system is running arm64, append -arm64 to workspace-optimizer. Otherwise not
@@ -13,12 +60,21 @@ docker_options=(
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry
 )
 
+# Make sure you have an image with the flags installed on your docker. For that, fork the rust-optimizer,
+# modify the main.rs file adding the feature flag you want to compile with, modify the DOCKER_TAG on the Makefile
+# and run make build.
+
 # Optimized builds
 if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
-  docker run "${docker_options[@]}" cosmwasm/workspace-optimizer-arm64:0.13.0
+  docker_command=("docker" "run" "${docker_options[@]}" "cosmwasm/workspace-optimizer-arm64:0.13.0$flag")
 else
-  docker run "${docker_options[@]}" cosmwasm/workspace-optimizer:0.13.0
+  docker_command=("docker" "run" "${docker_options[@]}" "cosmwasm/workspace-optimizer:0.13.0$flag")
 fi
+
+echo "${docker_command[@]}"
+
+# Execute the Docker command
+"${docker_command[@]}"
 
 # Check generated wasm file sizes
 $projectRootPath/scripts/check_artifacts_size.sh

--- a/scripts/deployment/deploy_env/base_chihuahua.env
+++ b/scripts/deployment/deploy_env/base_chihuahua.env
@@ -1,1 +1,1 @@
-export TXFLAG="--node $RPC --chain-id $CHAIN_ID --gas-prices 2$DENOM --gas auto --gas-adjustment 1.3 -y -b block --output json"
+export TXFLAG="--node $RPC --chain-id $CHAIN_ID --gas-prices 1$DENOM --gas auto --gas-adjustment 1.3 -y -b block --output json"

--- a/scripts/deployment/migrate_incentives.sh
+++ b/scripts/deployment/migrate_incentives.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+deployment_script_dir=$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+project_root_path=$(realpath "$0" | sed 's|\(.*\)/.*|\1|' | cd ../ | pwd)
+
+function append_incentive_contract_to_output() {
+  if [ $# -eq 3 ]; then
+    local incentive=$1
+    local pool_label=$2
+    local incentive_contract=$3
+  else
+    echo "append_incentive_contract_to_output needs the incentive, pool_label and incentive_contract"
+    exit 1
+  fi
+
+  tmpfile=$(mktemp)
+  jq --arg incentive_contract $incentive_contract --arg incentive $incentive --arg pool_label $pool_label '.pool_incentives += [{incentive: $incentive, pool_label: $pool_label, incentive_contract: $incentive_contract}]' $output_file >$tmpfile
+  mv $tmpfile $output_file
+  echo -e "\nStored incentive contract for incentive $incentive on $CHAIN_ID successfully\n"
+}
+
+function migrate_incentives() {
+  mkdir -p $project_root_path/scripts/deployment/output
+  liquidity_hub_output_file=$project_root_path/scripts/deployment/output/"$CHAIN_ID"_liquidity_hub_contracts.json
+
+  # get incentive factory address
+  incentive_factory_addr=$(jq -r '.contracts[] | select (.wasm == "incentive_factory.wasm") | .contract_address' $liquidity_hub_output_file)
+  query='{"incentives":{"limit":30}}'
+
+  incentives=$($BINARY query wasm contract-state smart $incentive_factory_addr "$query" --node $RPC -o json | jq -r '.data[].incentive_address')
+
+  for incentive in $incentives; do
+    echo -e "Migrating incentive $incentive"
+
+    MSG='{"migrate_incentive":{"incentive_address": "'$incentive'", "code_id": '$code_id'}}'
+    incentive_contract=$($BINARY tx wasm execute $incentive_factory_addr "$MSG" $TXFLAG --from $deployer_address | jq -r '.logs[].events[] | select(.type == "migrate") | .attributes[] | select(.key == "_contract_address") | .value')
+
+    if [ -z "$incentive_contract" ]; then
+      echo -e "There was an error migrating incentive $incentive\n"
+    fi
+
+    sleep $tx_delay
+  done
+
+  # update code id for incentives in the factory
+  MSG='{"update_config":{"incentive_code_id": '$code_id'}}'
+  $BINARY tx wasm execute $incentive_factory_addr "$MSG" $TXFLAG --from $deployer_address
+
+  echo -e "\n**** Incentives migration successful ****\n"
+}
+
+# Displays tool usage
+function display_usage() {
+  echo "WW Incentive Migrator"
+  echo -e "\nUsage:./migrate_incentives.sh [flag]. A single flag should be used, -c to specify the chain.\n"
+  echo -e "The script will fetch the incentives from the incentive factory and migrate them with the given code_id.\n"
+  echo -e "Available flags:\n"
+  echo -e "  -h \thelp"
+  echo -e "  -c \tThe chain where you want to migrate incentives (juno|juno-testnet|terra|terra-testnet|... check chain_env.sh for the complete list of supported chains)"
+  echo -e "  -i \tThe code_id you want to migrate the incentives to."
+}
+
+if [ -z $1 ]; then
+  display_usage
+  exit 0
+fi
+
+# get args
+optstring=':c:i:h'
+while getopts $optstring arg; do
+  source $deployment_script_dir/wallet_importer.sh
+
+  case "$arg" in
+  c)
+    chain=$OPTARG
+
+    source $deployment_script_dir/deploy_env/chain_env.sh
+    init_chain_env $OPTARG
+    if [[ "$chain" = "local" ]]; then
+      tx_delay=0.5
+    else
+      tx_delay=8
+    fi
+
+    import_deployer_wallet $chain
+    ;;
+  i)
+    code_id=$OPTARG
+    migrate_incentives
+    ;;
+  h)
+    display_usage
+    exit 0
+    ;;
+  :)
+    echo "Must supply an argument to -$OPTARG" >&2
+    exit 1
+    ;;
+  ?)
+    echo "Invalid option: -${OPTARG}"
+    display_usage
+    exit 2
+    ;;
+  esac
+done


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR adds a script to migrate the incentive contracts. Just specify the chain you want to migrate on, the code_id and your are done. Bear in mind you need to store the contract previously to get the code_id you want to migrate to.

This PR also adds cases to the release build script, so it optimizes the contracts using the right feature flags depending on which chain you intent to deploy. Bear in mind you need to have the rust optimizer docker images with the feature flags locally, as indicated in the script.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
