### PR TITLE
fix: unlock incentives so people can withdraw before the unlocking time finishes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "incentive"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/liquidity_hub/pool-network/incentive/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/incentive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incentive"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
 edition.workspace = true
 description = "An incentive manager for an LP token"

--- a/contracts/liquidity_hub/pool-network/incentive/src/execute/withdraw.rs
+++ b/contracts/liquidity_hub/pool-network/incentive/src/execute/withdraw.rs
@@ -21,13 +21,14 @@ pub fn withdraw(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, 
                 let position = &closed_positions[i];
 
                 // if unbonding timestamp is in the past, it's possible to withdraw
-                if env.block.time.seconds() > position.unbonding_timestamp {
-                    // add return tokens to sum
-                    return_token_count = return_token_count.checked_add(position.amount)?;
+                // let people out of jail in this version, done for specific pools where liquidity is being transferred
+                //if env.block.time.seconds() > position.unbonding_timestamp {
+                // add return tokens to sum
+                return_token_count = return_token_count.checked_add(position.amount)?;
 
-                    // remove position
-                    closed_positions.remove(i);
-                }
+                // remove position
+                closed_positions.remove(i);
+                //}
             }
 
             Ok(closed_positions)


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR unlocks the incentives so users can withdraw without waiting for the unlocking time to finish.

This is gonna be done in specific pools which liquidity is being moved.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
