### PR TITLE
chore: bump vault contract version before migration on terra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "vault"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/contract.rs
@@ -238,18 +238,15 @@ pub fn migrate(mut deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Respons
 
     check_contract_name(deps.storage, CONTRACT_NAME.to_string())?;
 
-    //let version: Version = CONTRACT_VERSION.parse()?;
+    let version: Version = CONTRACT_VERSION.parse()?;
     let storage_version: Version = get_contract_version(deps.storage)?.version.parse()?;
 
-    // we remove this block not to bump the version of the contract again as the migration was done
-    // already (without the token factory fix)
-
-    // if storage_version >= version {
-    //     return Err(ContractError::MigrateInvalidVersion {
-    //         current_version: storage_version,
-    //         new_version: version,
-    //     });
-    // }
+    if storage_version >= version {
+        return Err(ContractError::MigrateInvalidVersion {
+            current_version: storage_version,
+            new_version: version,
+        });
+    }
 
     if storage_version <= Version::parse("1.0.4")? {
         migrations::migrate_to_v110(deps.branch())?;

--- a/contracts/liquidity_hub/vault-network/vault/Cargo.toml
+++ b/contracts/liquidity_hub/vault-network/vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
 edition.workspace = true
 description = "Contract to handle a single vault that controls an asset"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -31,10 +31,10 @@ flag=""
 
 case $chain in
 
-juno)
+juno | terra)
   flag="-osmosis_token_factory"
   ;;
-terra | migaloo)
+migaloo)
   flag="-token_factory"
   ;;
 injective)


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR increments the vault contract version so we can migrate it on terra once we compile with the new token (osmosis) factory.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
