### PR TITLE
chore: remove add_native_decimals balance check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "terraswap-factory"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-factory"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
 	"Terraform Labs, PTE.",
 	"DELIGHT LABS",

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
@@ -1,10 +1,9 @@
 use cosmwasm_std::{
-    CosmosMsg, DepsMut, Env, MessageInfo, ReplyOn, Response, SubMsg, to_binary, wasm_execute,
+    to_binary, wasm_execute, CosmosMsg, DepsMut, Env, MessageInfo, ReplyOn, Response, SubMsg,
     WasmMsg,
 };
 
 use white_whale::pool_network;
-use white_whale::pool_network::{pair, trio};
 use white_whale::pool_network::asset::{AssetInfo, PairType};
 use white_whale::pool_network::pair::{
     FeatureToggle, InstantiateMsg as PairInstantiateMsg, MigrateMsg as PairMigrateMsg, PoolFee,
@@ -13,12 +12,13 @@ use white_whale::pool_network::trio::{
     FeatureToggle as TrioFeatureToggle, InstantiateMsg as TrioInstantiateMsg,
     MigrateMsg as TrioMigrateMsg, PoolFee as TrioPoolFee, RampAmp,
 };
+use white_whale::pool_network::{pair, trio};
 
 use crate::contract::{CREATE_PAIR_RESPONSE, CREATE_TRIO_RESPONSE};
 use crate::error::ContractError;
 use crate::state::{
-    add_allow_native_token, Config, CONFIG, pair_key, PAIRS, TMP_PAIR_INFO, TMP_TRIO_INFO, TmpPairInfo,
-    TmpTrioInfo, trio_key, TRIOS,
+    add_allow_native_token, pair_key, trio_key, Config, TmpPairInfo, TmpTrioInfo, CONFIG, PAIRS,
+    TMP_PAIR_INFO, TMP_TRIO_INFO, TRIOS,
 };
 
 /// Updates the contract's [Config]
@@ -367,7 +367,6 @@ pub fn remove_trio(
 /// Adds native/ibc token with decimals to the factory's whitelist so it can create pairs with that asset
 pub fn add_native_token_decimals(
     deps: DepsMut,
-    env: Env,
     denom: String,
     decimals: u8,
 ) -> Result<Response, ContractError> {

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/commands.rs
@@ -1,26 +1,24 @@
-use crate::contract::{CREATE_PAIR_RESPONSE, CREATE_TRIO_RESPONSE};
-
 use cosmwasm_std::{
-    to_binary, wasm_execute, CosmosMsg, DepsMut, Env, MessageInfo, ReplyOn, Response, SubMsg,
+    CosmosMsg, DepsMut, Env, MessageInfo, ReplyOn, Response, SubMsg, to_binary, wasm_execute,
     WasmMsg,
 };
 
 use white_whale::pool_network;
+use white_whale::pool_network::{pair, trio};
 use white_whale::pool_network::asset::{AssetInfo, PairType};
 use white_whale::pool_network::pair::{
     FeatureToggle, InstantiateMsg as PairInstantiateMsg, MigrateMsg as PairMigrateMsg, PoolFee,
 };
-use white_whale::pool_network::querier::query_balance;
 use white_whale::pool_network::trio::{
     FeatureToggle as TrioFeatureToggle, InstantiateMsg as TrioInstantiateMsg,
     MigrateMsg as TrioMigrateMsg, PoolFee as TrioPoolFee, RampAmp,
 };
-use white_whale::pool_network::{pair, trio};
 
+use crate::contract::{CREATE_PAIR_RESPONSE, CREATE_TRIO_RESPONSE};
 use crate::error::ContractError;
 use crate::state::{
-    add_allow_native_token, pair_key, trio_key, Config, TmpPairInfo, TmpTrioInfo, CONFIG, PAIRS,
-    TMP_PAIR_INFO, TMP_TRIO_INFO, TRIOS,
+    add_allow_native_token, Config, CONFIG, pair_key, PAIRS, TMP_PAIR_INFO, TMP_TRIO_INFO, TmpPairInfo,
+    TmpTrioInfo, trio_key, TRIOS,
 };
 
 /// Updates the contract's [Config]
@@ -373,11 +371,6 @@ pub fn add_native_token_decimals(
     denom: String,
     decimals: u8,
 ) -> Result<Response, ContractError> {
-    let balance = query_balance(&deps.querier, env.contract.address, denom.to_string())?;
-    if balance.is_zero() {
-        return Err(ContractError::InvalidVerificationBalance {});
-    }
-
     add_allow_native_token(deps.storage, denom.to_string(), decimals)?;
 
     Ok(Response::new().add_attributes(vec![

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/contract.rs
@@ -105,7 +105,7 @@ pub fn execute(
         ExecuteMsg::RemovePair { asset_infos } => commands::remove_pair(deps, env, asset_infos),
         ExecuteMsg::RemoveTrio { asset_infos } => commands::remove_trio(deps, env, asset_infos),
         ExecuteMsg::AddNativeTokenDecimals { denom, decimals } => {
-            commands::add_native_token_decimals(deps, env, denom, decimals)
+            commands::add_native_token_decimals(deps, denom, decimals)
         }
         ExecuteMsg::MigratePair { contract, code_id } => {
             commands::execute_migrate_pair(deps, contract, code_id)

--- a/contracts/liquidity_hub/pool-network/terraswap_factory/src/testing.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_factory/src/testing.rs
@@ -1241,26 +1241,6 @@ fn failed_add_allow_native_token_with_non_admin() {
 }
 
 #[test]
-fn failed_add_allow_native_token_with_zero_factory_balance() {
-    let mut deps = mock_dependencies(&[coin(0u128, "uluna".to_string())]);
-    deps = init(deps);
-
-    let msg = ExecuteMsg::AddNativeTokenDecimals {
-        denom: "uluna".to_string(),
-        decimals: 6u8,
-    };
-
-    let info = mock_info("addr0000", &[]);
-
-    let res = execute(deps.as_mut(), mock_env(), info, msg);
-    match res {
-        Ok(_) => panic!("should return ContractError::InvalidVerificationBalance"),
-        Err(ContractError::InvalidVerificationBalance {}) => (),
-        _ => panic!("should return ContractError::InvalidVerificationBalance"),
-    }
-}
-
-#[test]
 fn append_add_allow_native_token_with_already_exist_token() {
     let mut deps = mock_dependencies(&[coin(1u128, "uluna".to_string())]);
     deps = init(deps);


### PR DESCRIPTION
## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR removes the add_native_decimals balance check, since the pool factory is permissioned there's no risk on this one. Also, this change will allow allowing another wallet to create pools via authz without the need to send any balances to the contract.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
