### PR TITLE
ci: fix release action

### DIFF
--- a/.github/workflows/release-artifacts-on-tag.yaml
+++ b/.github/workflows/release-artifacts-on-tag.yaml
@@ -15,12 +15,6 @@ jobs:
           submodules: recursive
       - name: Build Artifacts
         run: |
-          $GITHUB_WORKSPACE/scripts/build_release.sh -c migaloo
-          tar -zcvf cosmwasm-artifacts_cosmwasm-token-factory.tar.gz artifacts
-          $GITHUB_WORKSPACE/scripts/build_release.sh -c injective
-          tar -zcvf cosmwasm-artifacts_injective.tar.gz artifacts
-          $GITHUB_WORKSPACE/scripts/build_release.sh -c terra
-          tar -zcvf cosmwasm-artifacts_osmosis-token-factory.tar.gz artifacts
           $GITHUB_WORKSPACE/scripts/build_release.sh -c chihuahua
           tar -zcvf cosmwasm-artifacts_no-token-factory.tar.gz artifacts
       - name: Get Artifacts Versions
@@ -29,8 +23,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            cosmwasm-artifacts_cosmwasm-token-factory.tar.gz
-            cosmwasm-artifacts_osmosis-token-factory.tar.gz
-            cosmwasm-artifacts_injective.tar.gz
             cosmwasm-artifacts_no-token-factory.tar.gz
             artifact_versions.txt


### PR DESCRIPTION

## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

This PR removes the custom token factory release builds  from the ci release script for the docker images used by the release script are not available in the docker hub.

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [ ] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
