### PR TITLE
ci: add vanilla variant to build release script for ci

### DIFF
--- a/.github/workflows/release-artifacts-on-tag.yaml
+++ b/.github/workflows/release-artifacts-on-tag.yaml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - name: Build Artifacts
         run: |
-          $GITHUB_WORKSPACE/scripts/build_release.sh -c chihuahua
+          $GITHUB_WORKSPACE/scripts/build_release.sh -c vanilla
           tar -zcvf cosmwasm-artifacts_no-token-factory.tar.gz artifacts
       - name: Get Artifacts Versions
         run: $GITHUB_WORKSPACE/scripts/get_artifacts_versions.sh > artifact_versions.txt

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -57,7 +57,7 @@ migaloo)
 injective)
   flag="-injective"
   ;;
-comdex | orai | sei) ;;
+comdex | orai | sei | vanilla) ;;
 
 \*)
   echo "Network $chain not defined"


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This adds the vanilla flavor of white whale to the release_build script, which builds without any feature flag.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
