### PR TITLE
chore: forces the protobuf version to be 3.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ cw20 = "1.0.1"
 cw20-base = { version = "1.1.0", features = ["library"] }
 cw-storage-plus = "1.1.0"
 cw-utils = "1.0.1"
-protobuf = { version = "3.2.0", features = ["with-bytes"] }
+protobuf = { version = "=3.2.0", features = ["with-bytes"] }
 schemars = "0.8.12"
 semver = "1.0.12"
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR forces the protobuf version to be exactly 3.2.0 to avoid issues with other dependencies trying to pull a different (higher) version. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
