### PR TITLE
ci: improve pre-commit hook

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,6 +18,9 @@ test FEATURE='':
     cargo test --features {{FEATURE}}
   fi
 
+fmt:
+  @just format
+
 format:
   cargo fmt --all
   find . -type f -iname "*.toml" -print0 | xargs -0 taplo format

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+export PATH=$PATH:/usr/local/bin
+
+#
+# White Whale contracts commit hook, used to make sure commits follow the conventional commits format.
+# See more at https://www.conventionalcommits.org/
+#
+# Install the hook with the --install option.
+#
+
+project_toplevel=$(git rev-parse --show-toplevel)
+git_directory=$(git rev-parse --git-dir)
+
+install_hook() {
+	mkdir -p "$git_directory/hooks"
+	ln -sfv "$project_toplevel/scripts/hooks/commit-msg.sh" "$git_directory/hooks/commit-msg"
+}
+
+if [ "$1" = "--install" ]; then
+	if [ -f "$git_directory/hooks/commit-msg" ]; then
+		read -r -p "There's an existing commit-msg hook. Do you want to overwrite it? [y/N] " response
+		case "$response" in
+		[yY][eE][sS] | [yY])
+			install_hook
+			;;
+		*)
+			printf "Skipping hook installation :("
+			exit $?
+			;;
+		esac
+	else
+		install_hook
+	fi
+	exit $?
+fi
+
+printf "Checking commit message format...\n"
+
+COMMIT_MSG_FILE="$1"
+
+if [ ! -f "$COMMIT_MSG_FILE" ]; then
+	echo "Error: Commit message file not found."
+	exit 1
+fi
+
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# Regular expression to match Conventional Commits format
+CONVENTIONAL_COMMIT_REGEX="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(\S+\))?: .+$"
+
+if ! echo "$COMMIT_MSG" | grep -qE "$CONVENTIONAL_COMMIT_REGEX"; then
+	echo "Commit message does not follow Conventional Commits format."
+	exit 1
+fi


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR improves the pre-commit hook, formatting not only rust files but also toml and shell scripts files. 

It also introduces a commit-msg hook, which makes sure the conventional commit format is being used. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
