### PR TITLE
fix: prevents sending very small balances when collecting fees from p…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "terraswap-pair"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "anybuf",
  "classic-bindings",

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-pair"
-version = "1.3.4"
+version = "1.3.5"
 authors = [
   "Terraform Labs, PTE.",
   "DELIGHT LABS",

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/commands.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/commands.rs
@@ -586,6 +586,8 @@ pub fn update_config(
     Ok(Response::new().add_attribute("action", "update_config"))
 }
 
+const MINIMUM_COLLECTABLE_BALANCE: Uint128 = Uint128::new(1_000u128);
+
 /// Collects all protocol fees accrued by the pool
 pub fn collect_protocol_fees(deps: DepsMut<TerraQuery>) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
@@ -610,7 +612,7 @@ pub fn collect_protocol_fees(deps: DepsMut<TerraQuery>) -> Result<Response, Cont
     let mut messages: Vec<CosmosMsg> = Vec::new();
     for protocol_fee in protocol_fees {
         // prevents trying to send 0 coins, which errors
-        if protocol_fee.amount != Uint128::zero() {
+        if protocol_fee.amount > MINIMUM_COLLECTABLE_BALANCE {
             messages.push(protocol_fee.into_msg(&deps.querier, config.fee_collector_addr.clone())?);
         }
     }


### PR DESCRIPTION
…ools

## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This prevents trying to send very small balances when collecting fees, which can lead the errors in luna classic due to the burn fee.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
