### PR TITLE
fix: ignore possible errors when  closing positions due to rewards ca…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "incentive"
-version = "1.0.6"
+version = "1.0.8"
 dependencies = [
  "classic-bindings",
  "cosmwasm-schema",

--- a/contracts/liquidity_hub/pool-network/incentive/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/incentive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incentive"
-version = "1.0.6"
+version = "1.0.8"
 authors = ["kaimen-sano <kaimen_sano@protonmail.com>"]
 edition.workspace = true
 description = "An incentive manager for an LP token"

--- a/contracts/liquidity_hub/pool-network/incentive/src/execute/close_position.rs
+++ b/contracts/liquidity_hub/pool-network/incentive/src/execute/close_position.rs
@@ -21,19 +21,11 @@ pub fn close_position(
 ) -> Result<Response, ContractError> {
     //query and check if the user has pending rewards
     let rewards_query_result = get_rewards(deps.as_ref(), info.sender.clone().into_string());
-    match rewards_query_result {
-        Ok(rewards_response) => {
-            // can't close a position if there are pending rewards
-            if !rewards_response.rewards.is_empty() {
-                return Err(ContractError::PendingRewards {});
-            }
-        }
-        Err(error) => {
-            //if it has nothing to claim, then close the position
-            match error {
-                ContractError::NothingToClaim {} => {}
-                _ => return Err(ContractError::InvalidReward {}),
-            }
+
+    if let Ok(rewards_response) = rewards_query_result {
+        // can't close a position if there are pending rewards
+        if !rewards_response.rewards.is_empty() {
+            return Err(ContractError::PendingRewards {});
         }
     }
 


### PR DESCRIPTION
…lculations

## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR allows users closing positions on incentives even if an error occurs when calculating rewards as they are closing the position anyway.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
