### PR TITLE
Document usage of just command line runner

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,8 +18,9 @@ The following are the tools you'll need:
 
 - [Git](https://git-scm.com/)
 - [Rust](https://rustup.rs/)
-- wasm32 target
+- wasm32 target set for Rust
 - [PyO3](https://pyo3.rs), which requires a Python installation **with a shared library** (see https://github.com/PyO3/pyo3/tree/main#using-python-from-rust for example instructions on installing this for Ubuntu)
+- [Just](https://just.systems/man/en/)
 
 ```bash
 $ rustup default stable
@@ -68,25 +69,26 @@ The following are the steps to fork the repository to your GitHub account and cl
 4. Install our pre-commit hook. **Do not skip this step**. This will make sure that your code doesn't have any issues and
    is formatted correctly before you even commit. If you don't install this, you risk your future pull request to fail on CI,
    which you will need to fix before we review it. - `./scripts/hooks/pre-commit.sh --install`
-5. Make your contributions locally. The following are recommendations so that it is easier for anyone to understand what
+5. Review CLI commands that can be used when developing in the repository by running `just`
+6. Make your contributions locally. The following are recommendations so that it is easier for anyone to understand what
    you are trying to achieve: - Please use [conventional commits](https://conventionalcommits.org) syntax. - Please make sure to use clear commit messages. - Please favor small commits instead of large ones.
-6. Make sure to update the schemas if you have modified the messages.
-   - `cargo schema`
-7. If you made protobuf changes, regenerate the appropriate protobuf rust files using [`protoc-gen-rust`](https://docs.rs/protobuf-codegen/latest/protobuf_codegen/#how-to-use-protoc-gen-rust)
-8. Make sure your code compiles, both for debug and production.
+7. Make sure to update the schemas if you have modified the messages.
+   - `just schemas`
+8. If you made protobuf changes, regenerate the appropriate protobuf rust files using [`protoc-gen-rust`](https://docs.rs/protobuf-codegen/latest/protobuf_codegen/#how-to-use-protoc-gen-rust)
+9. Make sure your code compiles, both for debug and production.
    - `cargo build`
    - `cargo wasm`
    - `./scripts/build_release.sh`
-9. Test your code. We strive for high quality code, so any changes you introduce need to be tested. We know testing contracts
-   can be difficult! If you are not sure how to create tests, please refer to existing ones or just ask us on our
-   [discord](https://discordapp.com/channels/908044702794801233/987301947440767006). Please note that **Untested code will be rejected** - `cargo test`
-10. Setup and use the provided githooks! These help speed up the review process pointing out common issues before a CI check like lints. To install the hook, run `scripts/hooks/pre-commit.sh --install`
-11. Push your changes to your repository.
+10. Test your code. We strive for high quality code, so any changes you introduce need to be tested. We know testing contracts
+    can be difficult! If you are not sure how to create tests, please refer to existing ones or just ask us on our
+    [discord](https://discordapp.com/channels/908044702794801233/987301947440767006). Please note that **Untested code will be rejected** - `cargo test`
+11. Setup and use the provided githooks! These help speed up the review process pointing out common issues before a CI check like lints. To install the hook, run `scripts/hooks/pre-commit.sh --install`
+12. Push your changes to your repository.
     - `git push --set-upstream $YOUR_ORIGIN $YOUR_BRANCH_NAME`
-12. Create a pull request. Go to your [repository](https://github.com/$USER/migaloo-core.git) and create a pull request
+13. Create a pull request. Go to your [repository](https://github.com/$USER/migaloo-core.git) and create a pull request
     against Migaloo's repository **main branch** as base. - Please fill in the template presented to you when creating the pull request, as it helps everybody understand what the PR is trying to achieve. - Follow the instructions on the PR template. Consider that a pull request that doesn't follow the template or is not filled in properly _will be considered incomplete_.
-13. Follow up the discussions on the PR as there might be requests from other members.
-14. Wait for your PR to be approved and merged.
+14. Follow up the discussions on the PR as there might be requests from other members.
+15. Wait for your PR to be approved and merged.
 
 ## Helping out in the issue tracker
 


### PR DESCRIPTION
## Description and Motivation

In #274 we introduced an env loader for the CLI to simplify and unify our commands used in the repository. This commit documents the usage of the `just` command runner for new users of the repository.

---

## Checklist:

- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
