### PR TITLE
fix: Add input append_body and generate_release_notes, set both to true

### DIFF
--- a/.github/workflows/release-artifacts-on-tag.yaml
+++ b/.github/workflows/release-artifacts-on-tag.yaml
@@ -23,6 +23,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: artifact_versions.txt
+          append_body: true
+          generate_release_notes: true
           files: |
             cosmwasm-artifacts_no-token-factory.tar.gz
             artifact_versions.txt


### PR DESCRIPTION
This should:
Allow us to pass the artifact versions.txt and have it appended to the generated release notes https://github.com/softprops/action-gh-release/blob/4634c16e79c963813287e889244c50009e7f0981/src/github.ts#L244

## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [X] The code is formatted properly `cargo fmt --all --`.
- [X] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [X] I have regenerated the schemas if needed `cargo schema`.
