### PR TITLE
Reorganize testing modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,7 @@ dependencies = [
  "thiserror",
  "whale-lair",
  "white-whale-std",
+ "white-whale-testing",
 ]
 
 [[package]]
@@ -1806,6 +1807,7 @@ dependencies = [
 name = "white-whale-testing"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",

--- a/contracts/liquidity_hub/vault-manager/Cargo.toml
+++ b/contracts/liquidity_hub/vault-manager/Cargo.toml
@@ -11,9 +11,9 @@ documentation.workspace = true
 publish.workspace = true
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+	# Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+	"contract.wasm",
+	"hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -51,3 +51,4 @@ terraswap-token.workspace = true
 terraswap-pair.workspace = true
 fee_collector.workspace = true
 anyhow.workspace = true
+white-whale-testing.workspace = true

--- a/contracts/liquidity_hub/vault-manager/tests/common/suite.rs
+++ b/contracts/liquidity_hub/vault-manager/tests/common/suite.rs
@@ -9,13 +9,13 @@ use cw_multi_test::{
     GovFailingModule, IbcFailingModule, StakeKeeper, WasmKeeper,
 };
 
-use white_whale_std::multi_test::stargate_mock::StargateMock;
 use white_whale_std::pool_network::asset::{Asset, AssetInfo, PairType};
 use white_whale_std::pool_network::pair::ExecuteMsg::ProvideLiquidity;
 use white_whale_std::pool_network::pair::{PoolFee, SimulationResponse};
 use white_whale_std::vault_manager::{
     Config, FilterVaultBy, InstantiateMsg, PaybackAssetResponse, ShareResponse, VaultsResponse,
 };
+use white_whale_testing::multi_test::stargate_mock::StargateMock;
 
 use crate::common::suite_contracts::{
     cw20_token_contract, fee_collector_contract, pair_contract, vault_manager_contract,

--- a/packages/white-whale-std/Cargo.toml
+++ b/packages/white-whale-std/Cargo.toml
@@ -3,10 +3,10 @@ name = "white-whale-std"
 version = "1.1.3"
 edition.workspace = true
 authors = [
-  "Kerber0x <kerber0x@protonmail.com>",
-  "0xFable <0xfabledev@gmail.com>",
-  "kaimen-sano <kaimen_sano@protonmail.com>",
-  "White Whale <info@whitewhale.money>",
+	"Kerber0x <kerber0x@protonmail.com>",
+	"0xFable <0xfabledev@gmail.com>",
+	"kaimen-sano <kaimen_sano@protonmail.com>",
+	"White Whale <info@whitewhale.money>",
 ]
 description = "Common White Whale types and utils"
 license.workspace = true
@@ -20,7 +20,7 @@ injective = ["token_factory"]
 osmosis = ["osmosis_token_factory"]
 token_factory = []
 osmosis_token_factory = [
-  "token_factory",
+	"token_factory",
 ] # this is for the osmosis token factory proto definitions, which defer from the standard token factory :)
 backtraces = ["cosmwasm-std/backtraces"]
 

--- a/packages/white-whale-std/src/lib.rs
+++ b/packages/white-whale-std/src/lib.rs
@@ -12,13 +12,6 @@ pub mod token_factory;
 
 pub mod coin;
 
-#[cfg(test)]
-#[cfg(any(
-    feature = "token_factory",
-    feature = "osmosis_token_factory",
-    feature = "injective"
-))]
-pub mod multi_test;
 #[cfg(any(
     feature = "token_factory",
     feature = "osmosis_token_factory",

--- a/packages/white-whale-std/src/tokenfactory/common.rs
+++ b/packages/white-whale-std/src/tokenfactory/common.rs
@@ -54,7 +54,7 @@ impl MsgTypes {
     }
 }
 
-pub(crate) trait EncodeMessage {
+pub trait EncodeMessage {
     /// Encodes the data as a proto doc
     fn encode(data: Self) -> Vec<u8>;
 

--- a/packages/white-whale-testing/Cargo.toml
+++ b/packages/white-whale-testing/Cargo.toml
@@ -14,9 +14,17 @@ documentation = "https://whitewhale.money"
 [features]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
+default = ["osmosis_token_factory"]
 backtraces = ["cosmwasm-std/backtraces"]
 
+injective = ["token_factory"]
+token_factory = []
+
+osmosis = ["osmosis_token_factory"]
+osmosis_token_factory = ["token_factory"]
+
 [dependencies]
+anyhow.workspace = true
 cosmwasm-std.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/packages/white-whale-testing/README.md
+++ b/packages/white-whale-testing/README.md
@@ -1,3 +1,3 @@
 # White Whale Testing
 
-White Whale Testing contains a series of utilities and convenient methods for testing White Whale's smart contracts. 
+White Whale Testing contains a series of utilities and convenient methods for testing White Whale's smart contracts.

--- a/packages/white-whale-testing/src/lib.rs
+++ b/packages/white-whale-testing/src/lib.rs
@@ -1,2 +1,9 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub mod integration;
+
+#[cfg(any(
+    feature = "token_factory",
+    feature = "osmosis_token_factory",
+    feature = "injective"
+))]
+pub mod multi_test;

--- a/packages/white-whale-testing/src/multi_test/mod.rs
+++ b/packages/white-whale-testing/src/multi_test/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(test)]
 pub mod stargate_mock;

--- a/packages/white-whale-testing/src/multi_test/stargate_mock.rs
+++ b/packages/white-whale-testing/src/multi_test/stargate_mock.rs
@@ -9,11 +9,11 @@ use cosmwasm_std::{
 };
 use cw_multi_test::{AppResponse, BankSudo, CosmosRouter, Stargate};
 
-use crate::tokenfactory::burn::MsgBurn;
-use crate::tokenfactory::common::EncodeMessage;
-use crate::tokenfactory::create_denom::{MsgCreateDenom, MsgCreateDenomResponse};
-use crate::tokenfactory::mint::MsgMint;
-use crate::tokenfactory::responses::{Params, QueryParamsResponse};
+use white_whale_std::tokenfactory::burn::MsgBurn;
+use white_whale_std::tokenfactory::common::EncodeMessage;
+use white_whale_std::tokenfactory::create_denom::{MsgCreateDenom, MsgCreateDenomResponse};
+use white_whale_std::tokenfactory::mint::MsgMint;
+use white_whale_std::tokenfactory::responses::{Params, QueryParamsResponse};
 
 pub struct StargateMock {}
 


### PR DESCRIPTION
## Description and Motivation

Moves the Osmosis mocking to the `white-whale-testing` package, rather than `white-whale-std` package. This lets us drop the `#[cfg(test)]` qualifiers which restrict integration tests from consuming our package.

This is a suitable restriction to drop, since it is likely that any code that is using `white-whale-testing` is performing testing operations, while our `white-whale-std` was public facing.

Fixing such issue is necessary, as we currently cannot `cargo test` on the `release/v2_contracts` branch.

## Related Issues

---

## Checklist:

- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [X] The code is formatted properly `cargo fmt --all --`.
- [X] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [X] I have regenerated the schemas if needed `cargo schema`.
