### PR TITLE
Feat/remove cw20 from pool manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "anybuf"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,15 +21,15 @@ checksum = "5c1a43b7dc14f396c5d1ac0eaea10f33cb40a2b46751d0869864d6d5abed20db"
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "base16ct"
@@ -34,9 +45,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bech32"
@@ -66,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,36 +93,30 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bnum"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cfg-if"
@@ -121,9 +132,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad24bc9dae9aac5dc124b4560e3f7678729d701f1bf3cb11140703d91f247d31"
+checksum = "9934c79e58d9676edfd592557dee765d2a6ef54c09d5aa2edb06156b00148966"
 dependencies = [
  "digest 0.10.7",
  "ecdsa",
@@ -135,11 +146,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca65635b768406eabdd28ba015cc3f2f863ca5a2677a7dc4c237b8ee1298efb3"
+checksum = "bc5e72e330bd3bdab11c52b5ecbdeb6a8697a004c57964caeb5d876f0b088b3c"
 dependencies = [
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -163,14 +174,14 @@ checksum = "f5d803bea6bd9ed61bd1ee0b4a2eb09ee20dbb539cc6e0b8795614d20952ebb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed4564772e5d779235f2d7353e3d66e37793065c3a5155a2978256bf4c5b7d5"
+checksum = "ef8666e572a3a2519010dde88c04d16e9339ae751b56b2bb35081fe3f7d6be74"
 dependencies = [
  "base64",
  "bech32",
@@ -190,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -249,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d8edce4b78785f36413f67387e4be7d0cb7d032b5d4164bcc024f9c3f3f2ea"
+checksum = "57de8d3761e46be863e3ac1eba8c8a976362a48c6abf240df1e26c3e421ee9e8"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -264,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fff029689ae89127cf6d7655809a68d712f3edbdb9686c70b018ba438b26ca"
+checksum = "cc392a5cb7e778e3f90adbf7faa43c4db7f35b6623224b08886d796718edb875"
 dependencies = [
  "anyhow",
  "bech32",
@@ -305,7 +316,7 @@ checksum = "a1d3bf2e0f341bb6cc100d7d441d31cf713fbd3ce0c511f91e79f14b40a889af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -363,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011c45920f8200bd5d32d4fe52502506f64f2f75651ab408054d4cfc75ca3a9b"
+checksum = "526e39bb20534e25a1cd0386727f0038f4da294e5e535729ba3ef54055246abd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -376,14 +387,13 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3ad456059901a36cfa68b596d85d579c3df2b797dae9950dc34c27e14e995f"
+checksum = "17ad79e86ea3707229bf78df94e08732e8f713207b4a77b2699755596725e7d9"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "cw-utils",
  "cw2",
  "cw20",
  "schemars",
@@ -394,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -410,7 +420,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -428,7 +438,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -436,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -456,24 +466,24 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
+ "hashbrown",
  "hex",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -512,33 +522,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fee-distributor-mock"
@@ -635,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -646,24 +642,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -678,10 +663,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
+name = "hashbrown"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hex"
@@ -748,15 +736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "integer-sqrt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,21 +745,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.10"
+name = "itertools"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
+ "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -796,15 +773,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -828,21 +805,21 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -859,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -875,9 +852,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "osmosis-std-derive"
@@ -885,10 +862,10 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4d482a16be198ee04e0f94e10dd9b8d02332dcf33bc5ea4b255e7e25eedc5df"
 dependencies = [
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -903,15 +880,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -956,25 +933,24 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
- "bitflags",
- "byteorder",
+ "bit-vec",
+ "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
  "rand",
  "rand_chacha",
  "rand_xorshift",
@@ -1011,10 +987,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1024,10 +1000,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.10.3",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1106,7 +1082,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1117,7 +1093,7 @@ checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1125,12 +1101,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1167,9 +1137,6 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -1177,7 +1144,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
@@ -1191,27 +1158,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rfc6979"
@@ -1225,16 +1183,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1244,16 +1201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schemars"
@@ -1276,20 +1233,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -1316,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
 dependencies = [
  "serde",
 ]
@@ -1331,7 +1288,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1342,14 +1299,14 @@ checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1392,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "spki"
@@ -1443,15 +1400,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1460,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1471,21 +1428,20 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1578,7 +1534,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1589,35 +1545,35 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.58",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"
@@ -1639,9 +1595,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unindent"
@@ -1755,12 +1711,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -1822,135 +1772,126 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ dependencies = [
  "thiserror",
  "whale-lair",
  "white-whale-std",
+ "white-whale-testing",
 ]
 
 [[package]]

--- a/contracts/liquidity_hub/pool-manager/Cargo.toml
+++ b/contracts/liquidity_hub/pool-manager/Cargo.toml
@@ -54,3 +54,4 @@ cw-multi-test.workspace = true
 anyhow.workspace = true
 test-case.workspace = true
 whale-lair.workspace = true
+white-whale-testing.workspace = true

--- a/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
+++ b/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
@@ -9,9 +9,7 @@
     "required": [
       "fee_collector_addr",
       "owner",
-      "pair_code_id",
-      "pool_creation_fee",
-      "token_code_id"
+      "pool_creation_fee"
     ],
     "properties": {
       "fee_collector_addr": {
@@ -20,84 +18,26 @@
       "owner": {
         "type": "string"
       },
-      "pair_code_id": {
-        "type": "integer",
-        "format": "uint64",
-        "minimum": 0.0
-      },
       "pool_creation_fee": {
-        "$ref": "#/definitions/Asset"
-      },
-      "token_code_id": {
-        "type": "integer",
-        "format": "uint64",
-        "minimum": 0.0
+        "$ref": "#/definitions/Coin"
       }
     },
     "additionalProperties": false,
     "definitions": {
-      "Asset": {
+      "Coin": {
         "type": "object",
         "required": [
           "amount",
-          "info"
+          "denom"
         ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
           },
-          "info": {
-            "$ref": "#/definitions/AssetInfo"
+          "denom": {
+            "type": "string"
           }
-        },
-        "additionalProperties": false
-      },
-      "AssetInfo": {
-        "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "token"
-            ],
-            "properties": {
-              "token": {
-                "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
-                "properties": {
-                  "contract_addr": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "native_token"
-            ],
-            "properties": {
-              "native_token": {
-                "type": "object",
-                "required": [
-                  "denom"
-                ],
-                "properties": {
-                  "denom": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
+        }
       },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
@@ -118,16 +58,16 @@
           "create_pair": {
             "type": "object",
             "required": [
-              "asset_infos",
+              "asset_denoms",
               "pair_type",
               "pool_fees",
               "token_factory_lp"
             ],
             "properties": {
-              "asset_infos": {
+              "asset_denoms": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/AssetInfo"
+                  "type": "string"
                 }
               },
               "pair_identifier": {
@@ -168,7 +108,7 @@
               "assets": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/Asset"
+                  "$ref": "#/definitions/Coin"
                 }
               },
               "pair_identifier": {
@@ -206,13 +146,13 @@
           "swap": {
             "type": "object",
             "required": [
-              "ask_asset",
+              "ask_asset_denom",
               "offer_asset",
               "pair_identifier"
             ],
             "properties": {
-              "ask_asset": {
-                "$ref": "#/definitions/AssetInfo"
+              "ask_asset_denom": {
+                "type": "string"
               },
               "belief_price": {
                 "anyOf": [
@@ -235,7 +175,7 @@
                 ]
               },
               "offer_asset": {
-                "$ref": "#/definitions/Asset"
+                "$ref": "#/definitions/Coin"
               },
               "pair_identifier": {
                 "type": "string"
@@ -268,7 +208,7 @@
               "assets": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/Asset"
+                  "$ref": "#/definitions/Coin"
                 }
               },
               "pair_identifier": {
@@ -389,18 +329,6 @@
         "additionalProperties": false
       },
       {
-        "type": "object",
-        "required": [
-          "receive"
-        ],
-        "properties": {
-          "receive": {
-            "$ref": "#/definitions/Cw20ReceiveMsg"
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -466,93 +394,20 @@
           }
         ]
       },
-      "Asset": {
+      "Coin": {
         "type": "object",
         "required": [
           "amount",
-          "info"
+          "denom"
         ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
           },
-          "info": {
-            "$ref": "#/definitions/AssetInfo"
-          }
-        },
-        "additionalProperties": false
-      },
-      "AssetInfo": {
-        "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "token"
-            ],
-            "properties": {
-              "token": {
-                "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
-                "properties": {
-                  "contract_addr": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "native_token"
-            ],
-            "properties": {
-              "native_token": {
-                "type": "object",
-                "required": [
-                  "denom"
-                ],
-                "properties": {
-                  "denom": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "Binary": {
-        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
-        "type": "string"
-      },
-      "Cw20ReceiveMsg": {
-        "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
-        "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
-        "properties": {
-          "amount": {
-            "$ref": "#/definitions/Uint128"
-          },
-          "msg": {
-            "$ref": "#/definitions/Binary"
-          },
-          "sender": {
+          "denom": {
             "type": "string"
           }
-        },
-        "additionalProperties": false
+        }
       },
       "Decimal": {
         "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
@@ -684,18 +539,18 @@
                 "type": "object",
                 "required": [
                   "pool_identifier",
-                  "token_in_info",
-                  "token_out_info"
+                  "token_in_denom",
+                  "token_out_denom"
                 ],
                 "properties": {
                   "pool_identifier": {
                     "type": "string"
                   },
-                  "token_in_info": {
-                    "$ref": "#/definitions/AssetInfo"
+                  "token_in_denom": {
+                    "type": "string"
                   },
-                  "token_out_info": {
-                    "$ref": "#/definitions/AssetInfo"
+                  "token_out_denom": {
+                    "type": "string"
                   }
                 },
                 "additionalProperties": false
@@ -708,16 +563,16 @@
       "SwapRoute": {
         "type": "object",
         "required": [
-          "ask_asset_info",
-          "offer_asset_info",
+          "ask_asset_denom",
+          "offer_asset_denom",
           "swap_operations"
         ],
         "properties": {
-          "ask_asset_info": {
-            "$ref": "#/definitions/AssetInfo"
+          "ask_asset_denom": {
+            "type": "string"
           },
-          "offer_asset_info": {
-            "$ref": "#/definitions/AssetInfo"
+          "offer_asset_denom": {
+            "type": "string"
           },
           "swap_operations": {
             "type": "array",
@@ -788,10 +643,10 @@
             ],
             "properties": {
               "ask_asset": {
-                "$ref": "#/definitions/Asset"
+                "$ref": "#/definitions/Coin"
               },
               "offer_asset": {
-                "$ref": "#/definitions/Asset"
+                "$ref": "#/definitions/Coin"
               },
               "pair_identifier": {
                 "type": "string"
@@ -818,10 +673,10 @@
             ],
             "properties": {
               "ask_asset": {
-                "$ref": "#/definitions/Asset"
+                "$ref": "#/definitions/Coin"
               },
               "offer_asset": {
-                "$ref": "#/definitions/Asset"
+                "$ref": "#/definitions/Coin"
               },
               "pair_identifier": {
                 "type": "string"
@@ -842,15 +697,15 @@
           "swap_route": {
             "type": "object",
             "required": [
-              "ask_asset_info",
-              "offer_asset_info"
+              "ask_asset_denom",
+              "offer_asset_denom"
             ],
             "properties": {
-              "ask_asset_info": {
-                "$ref": "#/definitions/AssetInfo"
+              "ask_asset_denom": {
+                "type": "string"
               },
-              "offer_asset_info": {
-                "$ref": "#/definitions/AssetInfo"
+              "offer_asset_denom": {
+                "type": "string"
               }
             },
             "additionalProperties": false
@@ -909,68 +764,20 @@
       }
     ],
     "definitions": {
-      "Asset": {
+      "Coin": {
         "type": "object",
         "required": [
           "amount",
-          "info"
+          "denom"
         ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
           },
-          "info": {
-            "$ref": "#/definitions/AssetInfo"
+          "denom": {
+            "type": "string"
           }
-        },
-        "additionalProperties": false
-      },
-      "AssetInfo": {
-        "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "token"
-            ],
-            "properties": {
-              "token": {
-                "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
-                "properties": {
-                  "contract_addr": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "native_token"
-            ],
-            "properties": {
-              "native_token": {
-                "type": "object",
-                "required": [
-                  "denom"
-                ],
-                "properties": {
-                  "denom": {
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
+        }
       },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
@@ -1098,7 +905,7 @@
       "type": "object",
       "required": [
         "asset_decimals",
-        "asset_infos",
+        "asset_denoms",
         "assets",
         "balances",
         "liquidity_token",
@@ -1114,16 +921,16 @@
             "minimum": 0.0
           }
         },
-        "asset_infos": {
+        "asset_denoms": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AssetInfo"
+            "type": "string"
           }
         },
         "assets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Asset"
+            "$ref": "#/definitions/Coin"
           }
         },
         "balances": {
@@ -1133,7 +940,7 @@
           }
         },
         "liquidity_token": {
-          "$ref": "#/definitions/AssetInfo"
+          "type": "string"
         },
         "pair_type": {
           "$ref": "#/definitions/PairType"
@@ -1144,68 +951,20 @@
       },
       "additionalProperties": false,
       "definitions": {
-        "Asset": {
+        "Coin": {
           "type": "object",
           "required": [
             "amount",
-            "info"
+            "denom"
           ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
             },
-            "info": {
-              "$ref": "#/definitions/AssetInfo"
+            "denom": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
-        },
-        "AssetInfo": {
-          "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "token"
-              ],
-              "properties": {
-                "token": {
-                  "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
-                  "properties": {
-                    "contract_addr": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": [
-                "native_token"
-              ],
-              "properties": {
-                "native_token": {
-                  "type": "object",
-                  "required": [
-                    "denom"
-                  ],
-                  "properties": {
-                    "denom": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            }
-          ]
+          }
         },
         "Decimal": {
           "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
@@ -1366,53 +1125,6 @@
         "$ref": "#/definitions/SwapOperation"
       },
       "definitions": {
-        "AssetInfo": {
-          "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "token"
-              ],
-              "properties": {
-                "token": {
-                  "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
-                  "properties": {
-                    "contract_addr": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": [
-                "native_token"
-              ],
-              "properties": {
-                "native_token": {
-                  "type": "object",
-                  "required": [
-                    "denom"
-                  ],
-                  "properties": {
-                    "denom": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
         "SwapOperation": {
           "oneOf": [
             {
@@ -1425,18 +1137,18 @@
                   "type": "object",
                   "required": [
                     "pool_identifier",
-                    "token_in_info",
-                    "token_out_info"
+                    "token_in_denom",
+                    "token_out_denom"
                   ],
                   "properties": {
                     "pool_identifier": {
                       "type": "string"
                     },
-                    "token_in_info": {
-                      "$ref": "#/definitions/AssetInfo"
+                    "token_in_denom": {
+                      "type": "string"
                     },
-                    "token_out_info": {
-                      "$ref": "#/definitions/AssetInfo"
+                    "token_out_denom": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false
@@ -1456,53 +1168,6 @@
         "$ref": "#/definitions/SwapRouteResponse"
       },
       "definitions": {
-        "AssetInfo": {
-          "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "token"
-              ],
-              "properties": {
-                "token": {
-                  "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
-                  "properties": {
-                    "contract_addr": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": [
-                "native_token"
-              ],
-              "properties": {
-                "native_token": {
-                  "type": "object",
-                  "required": [
-                    "denom"
-                  ],
-                  "properties": {
-                    "denom": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
         "SwapOperation": {
           "oneOf": [
             {
@@ -1515,18 +1180,18 @@
                   "type": "object",
                   "required": [
                     "pool_identifier",
-                    "token_in_info",
-                    "token_out_info"
+                    "token_in_denom",
+                    "token_out_denom"
                   ],
                   "properties": {
                     "pool_identifier": {
                       "type": "string"
                     },
-                    "token_in_info": {
-                      "$ref": "#/definitions/AssetInfo"
+                    "token_in_denom": {
+                      "type": "string"
                     },
-                    "token_out_info": {
-                      "$ref": "#/definitions/AssetInfo"
+                    "token_out_denom": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false
@@ -1539,15 +1204,15 @@
         "SwapRouteResponse": {
           "type": "object",
           "required": [
-            "ask_asset",
-            "offer_asset",
+            "ask_asset_denom",
+            "offer_asset_denom",
             "swap_route"
           ],
           "properties": {
-            "ask_asset": {
+            "ask_asset_denom": {
               "type": "string"
             },
-            "offer_asset": {
+            "offer_asset_denom": {
               "type": "string"
             },
             "swap_route": {

--- a/contracts/liquidity_hub/pool-manager/schema/raw/execute.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/execute.json
@@ -11,16 +11,16 @@
         "create_pair": {
           "type": "object",
           "required": [
-            "asset_infos",
+            "asset_denoms",
             "pair_type",
             "pool_fees",
             "token_factory_lp"
           ],
           "properties": {
-            "asset_infos": {
+            "asset_denoms": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/AssetInfo"
+                "type": "string"
               }
             },
             "pair_identifier": {
@@ -61,7 +61,7 @@
             "assets": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Asset"
+                "$ref": "#/definitions/Coin"
               }
             },
             "pair_identifier": {
@@ -99,13 +99,13 @@
         "swap": {
           "type": "object",
           "required": [
-            "ask_asset",
+            "ask_asset_denom",
             "offer_asset",
             "pair_identifier"
           ],
           "properties": {
-            "ask_asset": {
-              "$ref": "#/definitions/AssetInfo"
+            "ask_asset_denom": {
+              "type": "string"
             },
             "belief_price": {
               "anyOf": [
@@ -128,7 +128,7 @@
               ]
             },
             "offer_asset": {
-              "$ref": "#/definitions/Asset"
+              "$ref": "#/definitions/Coin"
             },
             "pair_identifier": {
               "type": "string"
@@ -161,7 +161,7 @@
             "assets": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Asset"
+                "$ref": "#/definitions/Coin"
               }
             },
             "pair_identifier": {
@@ -282,18 +282,6 @@
       "additionalProperties": false
     },
     {
-      "type": "object",
-      "required": [
-        "receive"
-      ],
-      "properties": {
-        "receive": {
-          "$ref": "#/definitions/Cw20ReceiveMsg"
-        }
-      },
-      "additionalProperties": false
-    },
-    {
       "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
       "type": "object",
       "required": [
@@ -359,93 +347,20 @@
         }
       ]
     },
-    "Asset": {
+    "Coin": {
       "type": "object",
       "required": [
         "amount",
-        "info"
+        "denom"
       ],
       "properties": {
         "amount": {
           "$ref": "#/definitions/Uint128"
         },
-        "info": {
-          "$ref": "#/definitions/AssetInfo"
-        }
-      },
-      "additionalProperties": false
-    },
-    "AssetInfo": {
-      "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "token"
-          ],
-          "properties": {
-            "token": {
-              "type": "object",
-              "required": [
-                "contract_addr"
-              ],
-              "properties": {
-                "contract_addr": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "native_token"
-          ],
-          "properties": {
-            "native_token": {
-              "type": "object",
-              "required": [
-                "denom"
-              ],
-              "properties": {
-                "denom": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "Binary": {
-      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
-      "type": "string"
-    },
-    "Cw20ReceiveMsg": {
-      "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
-      "type": "object",
-      "required": [
-        "amount",
-        "msg",
-        "sender"
-      ],
-      "properties": {
-        "amount": {
-          "$ref": "#/definitions/Uint128"
-        },
-        "msg": {
-          "$ref": "#/definitions/Binary"
-        },
-        "sender": {
+        "denom": {
           "type": "string"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
@@ -577,18 +492,18 @@
               "type": "object",
               "required": [
                 "pool_identifier",
-                "token_in_info",
-                "token_out_info"
+                "token_in_denom",
+                "token_out_denom"
               ],
               "properties": {
                 "pool_identifier": {
                   "type": "string"
                 },
-                "token_in_info": {
-                  "$ref": "#/definitions/AssetInfo"
+                "token_in_denom": {
+                  "type": "string"
                 },
-                "token_out_info": {
-                  "$ref": "#/definitions/AssetInfo"
+                "token_out_denom": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -601,16 +516,16 @@
     "SwapRoute": {
       "type": "object",
       "required": [
-        "ask_asset_info",
-        "offer_asset_info",
+        "ask_asset_denom",
+        "offer_asset_denom",
         "swap_operations"
       ],
       "properties": {
-        "ask_asset_info": {
-          "$ref": "#/definitions/AssetInfo"
+        "ask_asset_denom": {
+          "type": "string"
         },
-        "offer_asset_info": {
-          "$ref": "#/definitions/AssetInfo"
+        "offer_asset_denom": {
+          "type": "string"
         },
         "swap_operations": {
           "type": "array",

--- a/contracts/liquidity_hub/pool-manager/schema/raw/instantiate.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/instantiate.json
@@ -5,9 +5,7 @@
   "required": [
     "fee_collector_addr",
     "owner",
-    "pair_code_id",
-    "pool_creation_fee",
-    "token_code_id"
+    "pool_creation_fee"
   ],
   "properties": {
     "fee_collector_addr": {
@@ -16,84 +14,26 @@
     "owner": {
       "type": "string"
     },
-    "pair_code_id": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
-    },
     "pool_creation_fee": {
-      "$ref": "#/definitions/Asset"
-    },
-    "token_code_id": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
+      "$ref": "#/definitions/Coin"
     }
   },
   "additionalProperties": false,
   "definitions": {
-    "Asset": {
+    "Coin": {
       "type": "object",
       "required": [
         "amount",
-        "info"
+        "denom"
       ],
       "properties": {
         "amount": {
           "$ref": "#/definitions/Uint128"
         },
-        "info": {
-          "$ref": "#/definitions/AssetInfo"
+        "denom": {
+          "type": "string"
         }
-      },
-      "additionalProperties": false
-    },
-    "AssetInfo": {
-      "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "token"
-          ],
-          "properties": {
-            "token": {
-              "type": "object",
-              "required": [
-                "contract_addr"
-              ],
-              "properties": {
-                "contract_addr": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "native_token"
-          ],
-          "properties": {
-            "native_token": {
-              "type": "object",
-              "required": [
-                "denom"
-              ],
-              "properties": {
-                "denom": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
+      }
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/liquidity_hub/pool-manager/schema/raw/query.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/query.json
@@ -40,10 +40,10 @@
           ],
           "properties": {
             "ask_asset": {
-              "$ref": "#/definitions/Asset"
+              "$ref": "#/definitions/Coin"
             },
             "offer_asset": {
-              "$ref": "#/definitions/Asset"
+              "$ref": "#/definitions/Coin"
             },
             "pair_identifier": {
               "type": "string"
@@ -70,10 +70,10 @@
           ],
           "properties": {
             "ask_asset": {
-              "$ref": "#/definitions/Asset"
+              "$ref": "#/definitions/Coin"
             },
             "offer_asset": {
-              "$ref": "#/definitions/Asset"
+              "$ref": "#/definitions/Coin"
             },
             "pair_identifier": {
               "type": "string"
@@ -94,15 +94,15 @@
         "swap_route": {
           "type": "object",
           "required": [
-            "ask_asset_info",
-            "offer_asset_info"
+            "ask_asset_denom",
+            "offer_asset_denom"
           ],
           "properties": {
-            "ask_asset_info": {
-              "$ref": "#/definitions/AssetInfo"
+            "ask_asset_denom": {
+              "type": "string"
             },
-            "offer_asset_info": {
-              "$ref": "#/definitions/AssetInfo"
+            "offer_asset_denom": {
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -161,68 +161,20 @@
     }
   ],
   "definitions": {
-    "Asset": {
+    "Coin": {
       "type": "object",
       "required": [
         "amount",
-        "info"
+        "denom"
       ],
       "properties": {
         "amount": {
           "$ref": "#/definitions/Uint128"
         },
-        "info": {
-          "$ref": "#/definitions/AssetInfo"
+        "denom": {
+          "type": "string"
         }
-      },
-      "additionalProperties": false
-    },
-    "AssetInfo": {
-      "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "token"
-          ],
-          "properties": {
-            "token": {
-              "type": "object",
-              "required": [
-                "contract_addr"
-              ],
-              "properties": {
-                "contract_addr": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "native_token"
-          ],
-          "properties": {
-            "native_token": {
-              "type": "object",
-              "required": [
-                "denom"
-              ],
-              "properties": {
-                "denom": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
+      }
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/liquidity_hub/pool-manager/schema/raw/response_to_pair.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/response_to_pair.json
@@ -4,7 +4,7 @@
   "type": "object",
   "required": [
     "asset_decimals",
-    "asset_infos",
+    "asset_denoms",
     "assets",
     "balances",
     "liquidity_token",
@@ -20,16 +20,16 @@
         "minimum": 0.0
       }
     },
-    "asset_infos": {
+    "asset_denoms": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/AssetInfo"
+        "type": "string"
       }
     },
     "assets": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Asset"
+        "$ref": "#/definitions/Coin"
       }
     },
     "balances": {
@@ -39,7 +39,7 @@
       }
     },
     "liquidity_token": {
-      "$ref": "#/definitions/AssetInfo"
+      "type": "string"
     },
     "pair_type": {
       "$ref": "#/definitions/PairType"
@@ -50,68 +50,20 @@
   },
   "additionalProperties": false,
   "definitions": {
-    "Asset": {
+    "Coin": {
       "type": "object",
       "required": [
         "amount",
-        "info"
+        "denom"
       ],
       "properties": {
         "amount": {
           "$ref": "#/definitions/Uint128"
         },
-        "info": {
-          "$ref": "#/definitions/AssetInfo"
+        "denom": {
+          "type": "string"
         }
-      },
-      "additionalProperties": false
-    },
-    "AssetInfo": {
-      "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "token"
-          ],
-          "properties": {
-            "token": {
-              "type": "object",
-              "required": [
-                "contract_addr"
-              ],
-              "properties": {
-                "contract_addr": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "native_token"
-          ],
-          "properties": {
-            "native_token": {
-              "type": "object",
-              "required": [
-                "denom"
-              ],
-              "properties": {
-                "denom": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
+      }
     },
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",

--- a/contracts/liquidity_hub/pool-manager/schema/raw/response_to_swap_route.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/response_to_swap_route.json
@@ -6,53 +6,6 @@
     "$ref": "#/definitions/SwapOperation"
   },
   "definitions": {
-    "AssetInfo": {
-      "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "token"
-          ],
-          "properties": {
-            "token": {
-              "type": "object",
-              "required": [
-                "contract_addr"
-              ],
-              "properties": {
-                "contract_addr": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "native_token"
-          ],
-          "properties": {
-            "native_token": {
-              "type": "object",
-              "required": [
-                "denom"
-              ],
-              "properties": {
-                "denom": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "SwapOperation": {
       "oneOf": [
         {
@@ -65,18 +18,18 @@
               "type": "object",
               "required": [
                 "pool_identifier",
-                "token_in_info",
-                "token_out_info"
+                "token_in_denom",
+                "token_out_denom"
               ],
               "properties": {
                 "pool_identifier": {
                   "type": "string"
                 },
-                "token_in_info": {
-                  "$ref": "#/definitions/AssetInfo"
+                "token_in_denom": {
+                  "type": "string"
                 },
-                "token_out_info": {
-                  "$ref": "#/definitions/AssetInfo"
+                "token_out_denom": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false

--- a/contracts/liquidity_hub/pool-manager/schema/raw/response_to_swap_routes.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/response_to_swap_routes.json
@@ -6,53 +6,6 @@
     "$ref": "#/definitions/SwapRouteResponse"
   },
   "definitions": {
-    "AssetInfo": {
-      "description": "AssetInfo contract_addr is usually passed from the cw20 hook so we can trust the contract_addr is properly validated.",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "token"
-          ],
-          "properties": {
-            "token": {
-              "type": "object",
-              "required": [
-                "contract_addr"
-              ],
-              "properties": {
-                "contract_addr": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "native_token"
-          ],
-          "properties": {
-            "native_token": {
-              "type": "object",
-              "required": [
-                "denom"
-              ],
-              "properties": {
-                "denom": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "SwapOperation": {
       "oneOf": [
         {
@@ -65,18 +18,18 @@
               "type": "object",
               "required": [
                 "pool_identifier",
-                "token_in_info",
-                "token_out_info"
+                "token_in_denom",
+                "token_out_denom"
               ],
               "properties": {
                 "pool_identifier": {
                   "type": "string"
                 },
-                "token_in_info": {
-                  "$ref": "#/definitions/AssetInfo"
+                "token_in_denom": {
+                  "type": "string"
                 },
-                "token_out_info": {
-                  "$ref": "#/definitions/AssetInfo"
+                "token_out_denom": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -89,15 +42,15 @@
     "SwapRouteResponse": {
       "type": "object",
       "required": [
-        "ask_asset",
-        "offer_asset",
+        "ask_asset_denom",
+        "offer_asset_denom",
         "swap_route"
       ],
       "properties": {
-        "ask_asset": {
+        "ask_asset_denom": {
           "type": "string"
         },
-        "offer_asset": {
+        "offer_asset_denom": {
           "type": "string"
         },
         "swap_route": {

--- a/contracts/liquidity_hub/pool-manager/src/contract.rs
+++ b/contracts/liquidity_hub/pool-manager/src/contract.rs
@@ -25,7 +25,6 @@ pub fn instantiate(
     let config: Config = Config {
         fee_collector_addr: deps.api.addr_validate(&msg.fee_collector_addr)?,
         owner: deps.api.addr_validate(&msg.owner)?,
-        token_code_id: msg.token_code_id,
         // We must set a creation fee on instantiation to prevent spamming of pools
         pool_creation_fee: msg.pool_creation_fee,
         feature_toggle: FeatureToggle {

--- a/contracts/liquidity_hub/pool-manager/src/contract.rs
+++ b/contracts/liquidity_hub/pool-manager/src/contract.rs
@@ -53,7 +53,6 @@ pub fn execute(
             asset_denoms,
             pool_fees,
             pair_type,
-            token_factory_lp,
             pair_identifier,
         } => manager::commands::create_pair(
             deps,
@@ -62,11 +61,9 @@ pub fn execute(
             asset_denoms,
             pool_fees,
             pair_type,
-            token_factory_lp,
             pair_identifier,
         ),
         ExecuteMsg::ProvideLiquidity {
-            assets,
             slippage_tolerance,
             receiver,
             pair_identifier,
@@ -74,7 +71,6 @@ pub fn execute(
             deps,
             env,
             info,
-            assets,
             slippage_tolerance,
             receiver,
             pair_identifier,
@@ -106,16 +102,16 @@ pub fn execute(
                 pair_identifier,
             )
         }
-        ExecuteMsg::WithdrawLiquidity {
-            assets: _,
-            pair_identifier,
-        } => liquidity::commands::withdraw_liquidity(
-            deps,
-            env,
-            info.sender,
-            info.funds[0].amount,
-            pair_identifier,
-        ),
+        ExecuteMsg::WithdrawLiquidity { pair_identifier } => {
+            liquidity::commands::withdraw_liquidity(
+                deps,
+                env,
+                // TODO: why not sending info instead? there's no check that funds are sent
+                info.sender,
+                info.funds[0].amount,
+                pair_identifier,
+            )
+        }
         ExecuteMsg::AddNativeTokenDecimals { denom, decimals } => {
             manager::commands::add_native_token_decimals(deps, env, denom, decimals)
         }
@@ -233,9 +229,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
         )?)?),
         QueryMsg::SwapRoutes {} => Ok(to_json_binary(&get_swap_routes(deps)?)?),
         QueryMsg::Ownership {} => Ok(to_json_binary(&cw_ownable::get_ownership(deps.storage)?)?),
-        QueryMsg::Pair { pair_identifier } => {
-            Ok(to_json_binary(&PAIRS.load(deps.storage, pair_identifier)?)?)
-        }
+        QueryMsg::Pair { pair_identifier } => Ok(to_json_binary(
+            &PAIRS.load(deps.storage, &pair_identifier)?,
+        )?),
     }
 }
 

--- a/contracts/liquidity_hub/pool-manager/src/error.rs
+++ b/contracts/liquidity_hub/pool-manager/src/error.rs
@@ -7,7 +7,6 @@ use cw_ownable::OwnershipError;
 use cw_utils::PaymentError;
 use semver::Version;
 use thiserror::Error;
-use white_whale_std::pool_network::asset::AssetInfo;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
@@ -136,8 +135,8 @@ pub enum ContractError {
 
     #[error("Attempt to perform non-consecutive swap operation from previous output of {previous_output} to next input of {next_input}")]
     NonConsecutiveSwapOperations {
-        previous_output: AssetInfo,
-        next_input: AssetInfo,
+        previous_output: String,
+        next_input: String,
     },
 
     #[error("Invalid pair creation fee, expected {expected} got {amount}")]

--- a/contracts/liquidity_hub/pool-manager/src/helpers.rs
+++ b/contracts/liquidity_hub/pool-manager/src/helpers.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::ops::Mul;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Decimal, Decimal256, StdError, StdResult, Storage, Uint128, Uint256};
+use cosmwasm_std::{Coin, Decimal, Decimal256, StdError, StdResult, Storage, Uint128, Uint256};
 
 use white_whale_std::pool_network::asset::{Asset, AssetInfo, PairType};
 use white_whale_std::pool_network::pair::PoolFee;
@@ -426,8 +426,8 @@ pub struct OfferAmountComputation {
 pub fn assert_max_spread(
     belief_price: Option<Decimal>,
     max_spread: Option<Decimal>,
-    offer_asset: Asset,
-    return_asset: Asset,
+    offer_asset: Coin,
+    return_asset: Coin,
     spread_amount: Uint128,
     offer_decimal: u8,
     return_decimal: u8,
@@ -492,7 +492,7 @@ pub fn assert_max_spread(
 pub fn assert_slippage_tolerance(
     slippage_tolerance: &Option<Decimal>,
     deposits: &[Uint128; 2],
-    pools: &[Asset; 2],
+    pools: &[Coin; 2],
     pair_type: PairType,
     amount: Uint128,
     pool_token_supply: Uint128,

--- a/contracts/liquidity_hub/pool-manager/src/liquidity/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/liquidity/commands.rs
@@ -70,7 +70,7 @@ pub fn provide_liquidity(
     // // deduct protocol fee from pools
     // TODO: Replace with fill rewards msg
     let collected_protocol_fees = COLLECTABLE_PROTOCOL_FEES
-        .load(deps.storage, &pair.liquidity_token.to_string())
+        .load(deps.storage, &pair.liquidity_token)
         .unwrap_or_default();
     for pool in pool_assets.iter_mut() {
         let protocol_fee =

--- a/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
@@ -196,7 +196,7 @@ pub fn create_pair(
         },
     )?;
 
-    attributes.push(attr("lp_asset", lp_asset.to_string()));
+    attributes.push(attr("lp_asset", lp_asset));
 
     // TODO: this is already checked in the beginning of the function
     // #[cfg(any(

--- a/contracts/liquidity_hub/pool-manager/src/queries.rs
+++ b/contracts/liquidity_hub/pool-manager/src/queries.rs
@@ -1,9 +1,9 @@
 use std::cmp::Ordering;
 
-use cosmwasm_std::{Decimal256, Deps, Env, Fraction, Order, StdResult, Uint128};
+use cosmwasm_std::{Coin, Decimal256, Deps, Env, Fraction, Order, StdResult, Uint128};
 use white_whale_std::pool_manager::{SwapOperation, SwapRouteResponse};
 use white_whale_std::pool_network::{
-    asset::{Asset, AssetInfo, PairType},
+    asset::PairType,
     factory::NativeTokenDecimalsResponse,
     pair::{ReverseSimulationResponse, SimulationResponse},
     // router::SimulateSwapOperationsResponse,
@@ -30,26 +30,26 @@ pub fn query_native_token_decimal(
 pub fn query_simulation(
     deps: Deps,
     _env: Env,
-    offer_asset: Asset,
-    _ask_asset: Asset,
+    offer_asset: Coin,
+    _ask_asset: Coin,
     pair_identifier: String,
 ) -> Result<SimulationResponse, ContractError> {
     let pair_info = get_pair_by_identifier(&deps, pair_identifier)?;
     let pools = pair_info.assets.clone();
     // determine what's the offer and ask pool based on the offer_asset
-    let offer_pool: Asset;
-    let ask_pool: Asset;
+    let offer_pool: Coin;
+    let ask_pool: Coin;
     let offer_decimal: u8;
     let ask_decimal: u8;
     let decimals = get_decimals(&pair_info);
     // We now have the pools and pair info; we can now calculate the swap
     // Verify the pool
-    if offer_asset.info.equal(&pools[0].info) {
+    if offer_asset.denom == pools[0].denom {
         offer_pool = pools[0].clone();
         ask_pool = pools[1].clone();
         offer_decimal = decimals[0];
         ask_decimal = decimals[1];
-    } else if offer_asset.info.equal(&pools[1].info) {
+    } else if offer_asset.denom == pools[1].denom {
         offer_pool = pools[1].clone();
         ask_pool = pools[0].clone();
 
@@ -100,17 +100,17 @@ pub fn query_simulation(
 pub fn query_reverse_simulation(
     deps: Deps,
     _env: Env,
-    ask_asset: Asset,
-    _offer_asset: Asset,
+    ask_asset: Coin,
+    _offer_asset: Coin,
     pair_identifier: String,
 ) -> Result<ReverseSimulationResponse, ContractError> {
     let pair_info = get_pair_by_identifier(&deps, pair_identifier)?;
     let pools = pair_info.assets.clone();
 
     let decimals = get_decimals(&pair_info);
-    let offer_pool: Asset = pools[0].clone();
+    let offer_pool: Coin = pools[0].clone();
     let offer_decimal = decimals[0];
-    let ask_pool: Asset = pools[1].clone();
+    let ask_pool: Coin = pools[1].clone();
     let ask_decimal = decimals[1];
     let pool_fees = pair_info.pool_fees;
 
@@ -233,13 +233,13 @@ pub fn get_swap_routes(deps: Deps) -> Result<Vec<SwapRouteResponse>, ContractErr
         .map(|item| {
             let swap_info = item?;
             // Destructure key into (offer_asset, ask_asset)
-            let (offer_asset, ask_asset) = swap_info.0;
+            let (offer_asset_denom, ask_asset_denom) = swap_info.0;
             // Destructure value into vec of SwapOperation
             let swap_route = swap_info.1;
 
             Ok(SwapRouteResponse {
-                offer_asset,
-                ask_asset,
+                offer_asset_denom,
+                ask_asset_denom,
                 swap_route,
             })
         })
@@ -250,19 +250,16 @@ pub fn get_swap_routes(deps: Deps) -> Result<Vec<SwapRouteResponse>, ContractErr
 
 pub fn get_swap_route(
     deps: Deps,
-    offer_asset_info: AssetInfo,
-    ask_asset_info: AssetInfo,
+    offer_asset_denom: String,
+    ask_asset_denom: String,
 ) -> Result<Vec<SwapOperation>, ContractError> {
-    let swap_route_key = SWAP_ROUTES.key((
-        offer_asset_info.clone().get_label(&deps)?.as_str(),
-        ask_asset_info.clone().get_label(&deps)?.as_str(),
-    ));
+    let swap_route_key = SWAP_ROUTES.key((&offer_asset_denom, &ask_asset_denom));
 
     swap_route_key
         .load(deps.storage)
         .map_err(|_| ContractError::NoSwapRouteForAssets {
-            offer_asset: offer_asset_info.to_string(),
-            ask_asset: ask_asset_info.to_string(),
+            offer_asset: offer_asset_denom,
+            ask_asset: ask_asset_denom,
         })
 }
 

--- a/contracts/liquidity_hub/pool-manager/src/queries.rs
+++ b/contracts/liquidity_hub/pool-manager/src/queries.rs
@@ -34,7 +34,7 @@ pub fn query_simulation(
     _ask_asset: Coin,
     pair_identifier: String,
 ) -> Result<SimulationResponse, ContractError> {
-    let pair_info = get_pair_by_identifier(&deps, pair_identifier)?;
+    let pair_info = get_pair_by_identifier(&deps, &pair_identifier)?;
     let pools = pair_info.assets.clone();
     // determine what's the offer and ask pool based on the offer_asset
     let offer_pool: Coin;
@@ -104,7 +104,7 @@ pub fn query_reverse_simulation(
     _offer_asset: Coin,
     pair_identifier: String,
 ) -> Result<ReverseSimulationResponse, ContractError> {
-    let pair_info = get_pair_by_identifier(&deps, pair_identifier)?;
+    let pair_info = get_pair_by_identifier(&deps, &pair_identifier)?;
     let pools = pair_info.assets.clone();
 
     let decimals = get_decimals(&pair_info);

--- a/contracts/liquidity_hub/pool-manager/src/router/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/router/commands.rs
@@ -55,9 +55,10 @@ pub fn execute_swap_operations(
         .get_input_asset_info();
 
     let offer_asset = Coin {
-        denom: offer_asset_denom.to_owned(),
+        denom: offer_asset_denom.to_string(),
         amount: cw_utils::must_pay(&info, offer_asset_denom)?,
-    };
+    }
+    .clone();
 
     assert_operations(operations.clone())?;
 
@@ -152,7 +153,7 @@ pub fn execute_swap_operations(
             ("action", "execute_swap_operations"),
             ("sender", info.sender.as_str()),
             ("receiver", to.as_str()),
-            ("offer_info", &offer_asset.denom),
+            ("offer_info", offer_asset.denom.to_string().as_str()),
             ("offer_amount", &offer_asset.amount.to_string()),
             ("return_info", &target_asset_denom),
             ("return_amount", &receiver_balance.to_string()),

--- a/contracts/liquidity_hub/pool-manager/src/router/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/router/commands.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    coin, Addr, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, MessageInfo, Response, Uint128,
+    attr, coin, Addr, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, MessageInfo, Response, Uint128,
 };
 use white_whale_std::pool_manager::SwapOperation;
 
@@ -57,8 +57,7 @@ pub fn execute_swap_operations(
     let offer_asset = Coin {
         denom: offer_asset_denom.to_string(),
         amount: cw_utils::must_pay(&info, offer_asset_denom)?,
-    }
-    .clone();
+    };
 
     assert_operations(operations.clone())?;
 
@@ -150,13 +149,13 @@ pub fn execute_swap_operations(
         })
         .add_messages(fee_messages)
         .add_attributes(vec![
-            ("action", "execute_swap_operations"),
-            ("sender", info.sender.as_str()),
-            ("receiver", to.as_str()),
-            ("offer_info", offer_asset.denom.to_string().as_str()),
-            ("offer_amount", &offer_asset.amount.to_string()),
-            ("return_denom", &target_asset_denom),
-            ("return_amount", &receiver_balance.to_string()),
+            attr("action", "execute_swap_operations"),
+            attr("sender", info.sender.as_str()),
+            attr("receiver", to.as_str()),
+            attr("offer_info", offer_asset.denom),
+            attr("offer_amount", offer_asset.amount),
+            attr("return_denom", &target_asset_denom),
+            attr("return_amount", receiver_balance.to_string()),
         ])
         .add_attributes(swap_attributes))
 }

--- a/contracts/liquidity_hub/pool-manager/src/state.rs
+++ b/contracts/liquidity_hub/pool-manager/src/state.rs
@@ -124,8 +124,6 @@ fn calc_range_start(start_after: Option<[AssetInfoRaw; 2]>) -> Option<Vec<u8>> {
 pub struct Config {
     pub fee_collector_addr: Addr,
     pub owner: Addr,
-    // The code ID for CW20
-    pub token_code_id: u64,
     // We must set a creation fee on instantiation to prevent spamming of pools
     pub pool_creation_fee: Coin,
     //  Whether or not swaps, deposits, and withdrawals are enabled

--- a/contracts/liquidity_hub/pool-manager/src/state.rs
+++ b/contracts/liquidity_hub/pool-manager/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Api, Deps, Order, StdResult, Storage};
+use cosmwasm_std::{Addr, Api, Coin, Deps, Order, StdResult, Storage};
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, Map, UniqueIndex};
 use white_whale_std::pool_manager::{NPairInfo, SwapOperation};
 use white_whale_std::pool_network::asset::{Asset, AssetInfo, AssetInfoRaw};
@@ -64,7 +64,7 @@ pub fn get_decimals(pair_info: &NPairInfo) -> Vec<u8> {
 pub const SWAP_ROUTES: Map<(&str, &str), Vec<SwapOperation>> = Map::new("swap_routes");
 
 // Dyanmic Maps for Fee and Pair info
-pub const COLLECTABLE_PROTOCOL_FEES: Map<&str, Vec<Asset>> = Map::new("collected_protocol_fees");
+pub const COLLECTABLE_PROTOCOL_FEES: Map<&str, Vec<Coin>> = Map::new("collected_protocol_fees");
 pub const TOTAL_COLLECTED_PROTOCOL_FEES: Map<&str, Vec<Asset>> =
     Map::new("total_collected_protocol_fees");
 pub const ALL_TIME_BURNED_FEES: Map<&str, Vec<Asset>> = Map::new("all_time_burned_fees");
@@ -127,7 +127,7 @@ pub struct Config {
     // The code ID for CW20
     pub token_code_id: u64,
     // We must set a creation fee on instantiation to prevent spamming of pools
-    pub pool_creation_fee: Asset,
+    pub pool_creation_fee: Coin,
     //  Whether or not swaps, deposits, and withdrawals are enabled
     pub feature_toggle: FeatureToggle,
 }

--- a/contracts/liquidity_hub/pool-manager/src/swap/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/swap/commands.rs
@@ -79,8 +79,8 @@ pub fn swap(
         ("action", "swap"),
         ("sender", sender.as_str()),
         ("receiver", receiver.as_str()),
-        ("offer_asset", &offer_asset.denom.to_string()),
-        ("ask_asset", &swap_result.return_asset.denom.to_string()),
+        ("offer_asset", &offer_asset.denom),
+        ("ask_asset", &swap_result.return_asset.denom),
         ("offer_amount", &offer_asset.amount.to_string()),
         (
             "return_amount",

--- a/contracts/liquidity_hub/pool-manager/src/swap/perform_swap.rs
+++ b/contracts/liquidity_hub/pool-manager/src/swap/perform_swap.rs
@@ -38,7 +38,7 @@ pub fn perform_swap(
     belief_price: Option<Decimal>,
     max_spread: Option<Decimal>,
 ) -> Result<SwapResult, ContractError> {
-    let mut pair_info = get_pair_by_identifier(&deps.as_ref(), pair_identifier.clone())?;
+    let mut pair_info = get_pair_by_identifier(&deps.as_ref(), &pair_identifier)?;
     let pools = &pair_info.assets;
 
     // compute the offer and ask pool
@@ -100,11 +100,11 @@ pub fn perform_swap(
     if offer_asset.denom == pools[0].denom {
         pair_info.assets[0].amount += offer_amount;
         pair_info.assets[1].amount -= swap_computation.return_amount;
-        PAIRS.save(deps.storage, pair_identifier, &pair_info)?;
+        PAIRS.save(deps.storage, &pair_identifier, &pair_info)?;
     } else {
         pair_info.assets[1].amount += offer_amount;
         pair_info.assets[0].amount -= swap_computation.return_amount;
-        PAIRS.save(deps.storage, pair_identifier, &pair_info)?;
+        PAIRS.save(deps.storage, &pair_identifier, &pair_info)?;
     }
 
     // TODO: Might be handy to make the below fees into a helper method

--- a/contracts/liquidity_hub/pool-manager/src/swap/perform_swap.rs
+++ b/contracts/liquidity_hub/pool-manager/src/swap/perform_swap.rs
@@ -1,5 +1,5 @@
-use cosmwasm_std::{Decimal, DepsMut, Uint128};
-use white_whale_std::{pool_manager::NPairInfo, pool_network::asset::Asset};
+use cosmwasm_std::{Coin, Decimal, DepsMut, Uint128};
+use white_whale_std::pool_manager::NPairInfo;
 
 use crate::{
     helpers,
@@ -9,13 +9,13 @@ use crate::{
 
 pub struct SwapResult {
     /// The asset that should be returned to the user from the swap.
-    pub return_asset: Asset,
+    pub return_asset: Coin,
     /// The burn fee of `return_asset` associated with this swap transaction.
-    pub burn_fee_asset: Asset,
+    pub burn_fee_asset: Coin,
     /// The protocol fee of `return_asset` associated with this swap transaction.
-    pub protocol_fee_asset: Asset,
+    pub protocol_fee_asset: Coin,
     /// The swap fee of `return_asset` associated with this swap transaction.
-    pub swap_fee_asset: Asset,
+    pub swap_fee_asset: Coin,
 
     /// The pair that was traded.
     pub pair_info: NPairInfo,
@@ -33,7 +33,7 @@ pub struct SwapResult {
 /// of each field in [`SwapResult`] (besides fields like `spread_amount`).
 pub fn perform_swap(
     deps: DepsMut,
-    offer_asset: Asset,
+    offer_asset: Coin,
     pair_identifier: String,
     belief_price: Option<Decimal>,
     max_spread: Option<Decimal>,
@@ -42,20 +42,20 @@ pub fn perform_swap(
     let pools = &pair_info.assets;
 
     // compute the offer and ask pool
-    let offer_pool: Asset;
-    let ask_pool: Asset;
+    let offer_pool: Coin;
+    let ask_pool: Coin;
     let offer_decimal: u8;
     let ask_decimal: u8;
     let decimals = &pair_info.asset_decimals;
 
     // calculate the swap
     // first, set relevant variables
-    if offer_asset.info.equal(&pools[0].info) {
+    if offer_asset.denom == pools[0].denom {
         offer_pool = pools[0].clone();
         ask_pool = pools[1].clone();
         offer_decimal = decimals[0];
         ask_decimal = decimals[1];
-    } else if offer_asset.info.equal(&pools[1].info) {
+    } else if offer_asset.denom == pools[1].denom {
         offer_pool = pools[1].clone();
         ask_pool = pools[0].clone();
 
@@ -78,8 +78,8 @@ pub fn perform_swap(
         ask_decimal,
     )?;
 
-    let return_asset = Asset {
-        info: ask_pool.info.clone(),
+    let return_asset = Coin {
+        denom: ask_pool.denom.clone(),
         amount: swap_computation.return_amount,
     };
 
@@ -97,7 +97,7 @@ pub fn perform_swap(
 
     // State changes to the pairs balances
     // Deduct the return amount from the pool and add the offer amount to the pool
-    if offer_asset.info.equal(&pools[0].info) {
+    if offer_asset.denom == pools[0].denom {
         pair_info.assets[0].amount += offer_amount;
         pair_info.assets[1].amount -= swap_computation.return_amount;
         PAIRS.save(deps.storage, pair_identifier, &pair_info)?;
@@ -109,18 +109,18 @@ pub fn perform_swap(
 
     // TODO: Might be handy to make the below fees into a helper method
     // burn ask_asset from the pool
-    let burn_fee_asset = Asset {
-        info: ask_pool.info.clone(),
+    let burn_fee_asset = Coin {
+        denom: ask_pool.denom.clone(),
         amount: swap_computation.burn_fee_amount,
     };
     // Prepare a message to send the protocol fee and the swap fee to the protocol fee collector
-    let protocol_fee_asset = Asset {
-        info: ask_pool.info.clone(),
+    let protocol_fee_asset = Coin {
+        denom: ask_pool.denom.clone(),
         amount: swap_computation.protocol_fee_amount,
     };
     // Prepare a message to send the swap fee to the swap fee collector
-    let swap_fee_asset = Asset {
-        info: ask_pool.info,
+    let swap_fee_asset = Coin {
+        denom: ask_pool.denom,
         amount: swap_computation.swap_fee_amount,
     };
 

--- a/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
@@ -78,6 +78,7 @@ fn verify_ownership() {
         });
 }
 
+// add features `token_factory` so tests are compiled using the correct flag
 #[test]
 fn deposit_and_withdraw_sanity_check() {
     let mut suite = TestingSuite::default_with_balances(vec![

--- a/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
@@ -694,21 +694,13 @@ mod router {
 
         let swap_operations = vec![
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uwhale".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
+                token_in_denom: "uwhale".to_string(),
+                token_out_denom: "uluna".to_string(),
                 pool_identifier: "whale-uluna".to_string(),
             },
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uusd".to_string(),
-                },
+                token_in_denom: "uluna".to_string(),
+                token_out_denom: "uusd".to_string(),
                 pool_identifier: "uluna-uusd".to_string(),
             },
         ];
@@ -1115,21 +1107,13 @@ mod router {
 
         let swap_operations = vec![
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uwhale".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
+                token_in_denom: "uwhale".to_string(),
+                token_out_denom: "uluna".to_string(),
                 pool_identifier: "whale-uluna".to_string(),
             },
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uwhale".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
+                token_in_denom: "uwhale".to_string(),
+                token_out_denom: "uluna".to_string(),
                 pool_identifier: "whale-uluna".to_string(),
             },
         ];
@@ -1145,12 +1129,8 @@ mod router {
                 assert_eq!(
                     result.unwrap_err().downcast_ref::<self::ContractError>(),
                     Some(&ContractError::NonConsecutiveSwapOperations {
-                        previous_output: AssetInfo::NativeToken {
-                            denom: "uluna".to_string()
-                        },
-                        next_input: AssetInfo::NativeToken {
-                            denom: "uwhale".to_string()
-                        }
+                        previous_output: "uluna".to_string(),
+                        next_input: "uwhale".to_string()
                     })
                 );
             },
@@ -1325,21 +1305,13 @@ mod router {
 
         let swap_operations = vec![
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uwhale".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
+                token_in_denom: "uwhale".to_string(),
+                token_out_denom: "uluna".to_string(),
                 pool_identifier: "whale-uluna".to_string(),
             },
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uusd".to_string(),
-                },
+                token_in_denom: "uluna".to_string(),
+                token_out_denom: "uusd".to_string(),
                 pool_identifier: "uluna-uusd".to_string(),
             },
         ];
@@ -1599,21 +1571,13 @@ mod router {
 
         let swap_operations = vec![
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uwhale".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
+                token_in_denom: "uwhale".to_string(),
+                token_out_denom: "uluna".to_string(),
                 pool_identifier: "whale-uluna".to_string(),
             },
             white_whale_std::pool_manager::SwapOperation::WhaleSwap {
-                token_in_info: AssetInfo::NativeToken {
-                    denom: "uluna".to_string(),
-                },
-                token_out_info: AssetInfo::NativeToken {
-                    denom: "uusd".to_string(),
-                },
+                token_in_denom: "uluna".to_string(),
+                token_out_denom: "uusd".to_string(),
                 pool_identifier: "uluna-uusd".to_string(),
             },
         ];

--- a/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
@@ -67,11 +67,11 @@ impl TestingSuite {
         self
     }
 
-    pub(crate) fn get_time(&mut self) -> Timestamp {
+    pub(crate) fn _get_time(&mut self) -> Timestamp {
         self.app.block_info().time
     }
 
-    pub(crate) fn increase_allowance(
+    pub(crate) fn _increase_allowance(
         &mut self,
         sender: Addr,
         cw20contract: Addr,
@@ -438,7 +438,7 @@ impl TestingSuite {
     }
 
     #[track_caller]
-    pub(crate) fn withdraw_liquidity(
+    pub(crate) fn _withdraw_liquidity(
         &mut self,
         sender: Addr,
         pair_identifier: String,
@@ -489,7 +489,7 @@ impl TestingSuite {
         self
     }
 
-    pub(crate) fn query_pair_info(
+    pub(crate) fn _query_pair_info(
         &self,
         pair_identifier: String,
         result: impl Fn(StdResult<NPairInfo>),
@@ -586,7 +586,7 @@ impl TestingSuite {
         self
     }
 
-    pub(crate) fn query_lp_token(&mut self, identifier: String, _sender: String) -> String {
+    pub(crate) fn _query_lp_token(&mut self, identifier: String, _sender: String) -> String {
         // Get the LP token from Config
         let lp_token_response: NPairInfo = self
             .app

--- a/packages/white-whale-std/src/pool_manager.rs
+++ b/packages/white-whale-std/src/pool_manager.rs
@@ -18,9 +18,8 @@ pub enum SwapOperation {
     },
 }
 
-// TODO: is this really needed???
 impl SwapOperation {
-    /// Retrieves the `token_in_denom` [`AssetInfo`] used for this swap operation.
+    /// Retrieves the `token_in_denom` used for this swap operation.
     pub fn get_input_asset_info(&self) -> &String {
         match self {
             SwapOperation::WhaleSwap { token_in_denom, .. } => token_in_denom,
@@ -99,8 +98,9 @@ pub struct StableSwapParams {
 #[cw_serde]
 pub struct NPairInfo {
     pub asset_denoms: Vec<String>,
-    pub liquidity_token: String,
+    pub lp_denom: String,
     pub asset_decimals: Vec<u8>,
+    // TODO: balances is included in assets, might be redundant
     pub balances: Vec<Uint128>,
     pub assets: Vec<Coin>,
     pub pair_type: PairType,
@@ -129,12 +129,10 @@ pub enum ExecuteMsg {
         // TODO: Remap to NPoolFee maybe
         pool_fees: PoolFee,
         pair_type: PairType,
-        token_factory_lp: bool,
         pair_identifier: Option<String>,
     },
     /// Provides liquidity to the pool
     ProvideLiquidity {
-        assets: Vec<Coin>,
         slippage_tolerance: Option<Decimal>,
         receiver: Option<String>,
         pair_identifier: String,
@@ -148,13 +146,15 @@ pub enum ExecuteMsg {
         to: Option<String>,
         pair_identifier: String,
     },
-    // /// Withdraws liquidity from the pool. Used only when the LP is a token factory token.
+    // /// Withdraws liquidity from the pool.
     WithdrawLiquidity {
-        assets: Vec<Coin>,
         pair_identifier: String,
     },
     /// Adds native token info to the contract so it can instantiate pair contracts that include it
-    AddNativeTokenDecimals { denom: String, decimals: u8 },
+    AddNativeTokenDecimals {
+        denom: String,
+        decimals: u8,
+    },
 
     /// Execute multiple [`SwapOperations`] to allow for multi-hop swaps.
     ExecuteSwapOperations {
@@ -190,7 +190,9 @@ pub enum ExecuteMsg {
     //     receiver: String,
     // },
     /// Adds swap routes to the router.
-    AddSwapRoutes { swap_routes: Vec<SwapRoute> },
+    AddSwapRoutes {
+        swap_routes: Vec<SwapRoute>,
+    },
 }
 
 #[cw_ownable_query]

--- a/packages/white-whale-std/src/pool_manager.rs
+++ b/packages/white-whale-std/src/pool_manager.rs
@@ -113,8 +113,6 @@ impl NPairInfo {}
 #[cw_serde]
 pub struct InstantiateMsg {
     pub fee_collector_addr: String,
-    pub token_code_id: u64,
-    pub pair_code_id: u64,
     pub owner: String,
     pub pool_creation_fee: Coin,
 }

--- a/packages/white-whale-std/src/whale_lair.rs
+++ b/packages/white-whale-std/src/whale_lair.rs
@@ -1,4 +1,4 @@
-use crate::pool_network::asset::{Asset, AssetInfo, ToCoins};
+use crate::pool_network::asset::{Asset, AssetInfo};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
     to_json_binary, Addr, Coin, CosmosMsg, Decimal, StdResult, Timestamp, Uint128, Uint64, WasmMsg,
@@ -86,7 +86,7 @@ pub enum ExecuteMsg {
     /// V2 MESSAGES
 
     /// Fills the whale lair with new rewards.
-    FillRewards { assets: Vec<Asset> },
+    FillRewards { assets: Vec<Coin> },
     //todo to be renamed to FillRewards once the cw20 token support has been removed from the other v2 contracts
     /// Fills the whale lair with new rewards.
     FillRewardsCoin,
@@ -170,13 +170,13 @@ pub struct BondingWeightResponse {
 }
 
 /// Creates a message to fill rewards on the whale lair contract.
-pub fn fill_rewards_msg(contract_addr: String, assets: Vec<Asset>) -> StdResult<CosmosMsg> {
+pub fn fill_rewards_msg(contract_addr: String, assets: Vec<Coin>) -> StdResult<CosmosMsg> {
     Ok(CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr,
         msg: to_json_binary(&ExecuteMsg::FillRewards {
             assets: assets.clone(),
         })?,
-        funds: assets.to_coins()?,
+        funds: assets,
     }))
 }
 


### PR DESCRIPTION
## Description and Motivation

This PR removes all cw20 implementations from the pool manager. Once merged, the Pool Manager will no longer support CW20 tokens, it will only work using token factory tokens.

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

<!--

(Draft) Remove cw20 from Pool Manager

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
