### PR TITLE
fix(smart-contracts): remove balances from PairInfo & fix minor errors

### DIFF
--- a/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
+++ b/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
@@ -60,8 +60,7 @@
             "required": [
               "asset_denoms",
               "pair_type",
-              "pool_fees",
-              "token_factory_lp"
+              "pool_fees"
             ],
             "properties": {
               "asset_denoms": {
@@ -81,9 +80,6 @@
               },
               "pool_fees": {
                 "$ref": "#/definitions/PoolFee"
-              },
-              "token_factory_lp": {
-                "type": "boolean"
               }
             },
             "additionalProperties": false
@@ -101,16 +97,9 @@
           "provide_liquidity": {
             "type": "object",
             "required": [
-              "assets",
               "pair_identifier"
             ],
             "properties": {
-              "assets": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/Coin"
-                }
-              },
               "pair_identifier": {
                 "type": "string"
               },
@@ -201,16 +190,9 @@
           "withdraw_liquidity": {
             "type": "object",
             "required": [
-              "assets",
               "pair_identifier"
             ],
             "properties": {
-              "assets": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/Coin"
-                }
-              },
               "pair_identifier": {
                 "type": "string"
               }
@@ -901,14 +883,13 @@
     },
     "pair": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "NPairInfo",
+      "title": "PairInfo",
       "type": "object",
       "required": [
         "asset_decimals",
         "asset_denoms",
         "assets",
-        "balances",
-        "liquidity_token",
+        "lp_denom",
         "pair_type",
         "pool_fees"
       ],
@@ -933,13 +914,7 @@
             "$ref": "#/definitions/Coin"
           }
         },
-        "balances": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Uint128"
-          }
-        },
-        "liquidity_token": {
+        "lp_denom": {
           "type": "string"
         },
         "pair_type": {

--- a/contracts/liquidity_hub/pool-manager/schema/raw/execute.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/execute.json
@@ -13,8 +13,7 @@
           "required": [
             "asset_denoms",
             "pair_type",
-            "pool_fees",
-            "token_factory_lp"
+            "pool_fees"
           ],
           "properties": {
             "asset_denoms": {
@@ -34,9 +33,6 @@
             },
             "pool_fees": {
               "$ref": "#/definitions/PoolFee"
-            },
-            "token_factory_lp": {
-              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -54,16 +50,9 @@
         "provide_liquidity": {
           "type": "object",
           "required": [
-            "assets",
             "pair_identifier"
           ],
           "properties": {
-            "assets": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Coin"
-              }
-            },
             "pair_identifier": {
               "type": "string"
             },
@@ -154,16 +143,9 @@
         "withdraw_liquidity": {
           "type": "object",
           "required": [
-            "assets",
             "pair_identifier"
           ],
           "properties": {
-            "assets": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Coin"
-              }
-            },
             "pair_identifier": {
               "type": "string"
             }

--- a/contracts/liquidity_hub/pool-manager/schema/raw/response_to_pair.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/response_to_pair.json
@@ -1,13 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "NPairInfo",
+  "title": "PairInfo",
   "type": "object",
   "required": [
     "asset_decimals",
     "asset_denoms",
     "assets",
-    "balances",
-    "liquidity_token",
+    "lp_denom",
     "pair_type",
     "pool_fees"
   ],
@@ -32,13 +31,7 @@
         "$ref": "#/definitions/Coin"
       }
     },
-    "balances": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Uint128"
-      }
-    },
-    "liquidity_token": {
+    "lp_denom": {
       "type": "string"
     },
     "pair_type": {

--- a/contracts/liquidity_hub/pool-manager/src/contract.rs
+++ b/contracts/liquidity_hub/pool-manager/src/contract.rs
@@ -3,7 +3,6 @@ use crate::queries::{get_swap_route, get_swap_routes};
 use crate::state::{Config, MANAGER_CONFIG, PAIRS, PAIR_COUNTER};
 use crate::{liquidity, manager, queries, router, swap};
 #[cfg(not(feature = "library"))]
-use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     entry_point, to_json_binary, Addr, Api, Binary, Deps, DepsMut, Env, MessageInfo, Response,
 };

--- a/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
@@ -25,8 +25,8 @@ pub const LP_SYMBOL: &str = "uLP";
 /// # Example
 ///
 /// ```rust
-/// # use cosmwasm_std::{DepsMut, Decimal, Env, MessageInfo, Response, CosmosMsg, WasmMsg, to_binary};
-/// # use white_whale_std::pool_network::{asset::{AssetInfo, PairType}, pair::PoolFee};
+/// # use cosmwasm_std::{DepsMut, Decimal, Env, MessageInfo, Response, CosmosMsg, WasmMsg, to_json_binary};
+/// # use white_whale_std::pool_network::{asset::{PairType}, pair::PoolFee};
 /// # use white_whale_std::fee::Fee;
 /// # use pool_manager::error::ContractError;
 /// # use pool_manager::manager::commands::MAX_ASSETS_PER_POOL;
@@ -35,8 +35,8 @@ pub const LP_SYMBOL: &str = "uLP";
 /// #
 /// # fn example(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
 /// let asset_infos = vec![
-///     AssetInfo::NativeToken { denom: "uatom".into() },
-///     AssetInfo::NativeToken { denom: "uscrt".into() },
+///     "uatom".into(),
+///     "uscrt".into(),
 /// ];
 /// #[cfg(not(feature = "osmosis"))]
 /// let pool_fees = PoolFee {
@@ -69,7 +69,7 @@ pub const LP_SYMBOL: &str = "uLP";
 /// let pair_type = PairType::ConstantProduct;
 /// let token_factory_lp = false;
 ///
-/// let response = create_pair(deps, env, info, asset_infos, pool_fees, pair_type, token_factory_lp, None)?;
+/// let response = create_pair(deps, env, info, asset_infos, pool_fees, pair_type, None)?;
 /// # Ok(response)
 /// # }
 /// ```
@@ -117,14 +117,15 @@ pub fn create_pair(
             //todo pass the asset_decimals in the create_pair msg. Let the user creating the pool
             // defining the decimals, they are incentivized to do it right as they are paying a fee
 
-            // query_native_decimals(
-            //     &deps.querier,
-            //     env.contract.address.clone(),
-            //     asset.to_string(),
-            // )
+            let _ = query_native_decimals(
+                &deps.querier,
+                env.contract.address.clone(),
+                asset.to_string(),
+            );
+
             0u8
         })
-        .collect::<Result<Vec<u8>, _>>()?;
+        .collect::<Vec<u8>>();
 
     // Check if the asset infos are the same
     if asset_denoms
@@ -181,7 +182,6 @@ pub fn create_pair(
             asset_decimals: asset_decimals_vec,
             pool_fees,
             assets,
-            balances: vec![Uint128::zero(); asset_denoms.len()],
         },
     )?;
 

--- a/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
@@ -177,7 +177,7 @@ pub fn create_pair(
         &identifier,
         &PairInfo {
             asset_denoms,
-            pair_type,
+            pair_type: pair_type.clone(),
             lp_denom: lp_asset.clone(),
             asset_decimals: asset_decimals_vec,
             pool_fees,

--- a/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
+++ b/contracts/liquidity_hub/pool-manager/src/manager/commands.rs
@@ -176,8 +176,8 @@ pub fn create_pair(
         deps.storage,
         &identifier,
         &PairInfo {
-            asset_denoms: asset_denoms.clone(),
-            pair_type: pair_type.clone(),
+            asset_denoms,
+            pair_type,
             lp_denom: lp_asset.clone(),
             asset_decimals: asset_decimals_vec,
             pool_fees,

--- a/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
@@ -173,6 +173,7 @@ fn deposit_and_withdraw_sanity_check() {
         // creator should have 999_000 LP shares (1M - MINIMUM_LIQUIDITY_AMOUNT)
         .query_all_balances(creator.to_string(), |result| {
             let balances = result.unwrap();
+            println!("{:?}", balances);
             assert!(balances.iter().any(|coin| {
                 coin.denom == lp_denom && coin.amount == Uint128::from(999_000u128)
             }));

--- a/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
@@ -77,7 +77,7 @@ impl TestingSuite {
     pub(crate) fn get_lp_denom(&self, pair_id: String) -> String {
         // TODO: this should have
         format!(
-            "factory/{}/u{}.vault.{}.{}",
+            "factory/{}/u{}.pool.{}.{}",
             self.pool_manager_addr, pair_id, pair_id, LP_SYMBOL
         )
     }

--- a/packages/white-whale-std/src/pool_manager.rs
+++ b/packages/white-whale-std/src/pool_manager.rs
@@ -100,8 +100,6 @@ pub struct PairInfo {
     pub asset_denoms: Vec<String>,
     pub lp_denom: String,
     pub asset_decimals: Vec<u8>,
-    // TODO: balances is included in assets, might be redundant
-    pub balances: Vec<Uint128>,
     pub assets: Vec<Coin>,
     pub pair_type: PairType,
     pub pool_fees: PoolFee,


### PR DESCRIPTION
## Description and Motivation

This PR removes balances from `PairInfo`, as it doesn't provide any value. The balances are being held in assets already.

The previous branch, `release/v2_contracts`, had a couple of errors that were shown at compile time that are now fixed.

It also fixes the `pool-manager` tests that were not passing.

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

#307 

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
