### PR TITLE
refactor: add SimulationResponse and ReverseSimulationResponse to the…

### DIFF
--- a/packages/white-whale-std/src/pool_manager.rs
+++ b/packages/white-whale-std/src/pool_manager.rs
@@ -1,12 +1,6 @@
 use std::fmt;
 
-use crate::{
-    fee::PoolFee,
-    pool_network::{
-        asset::PairType,
-        pair::{ReverseSimulationResponse, SimulationResponse},
-    },
-};
+use crate::{fee::PoolFee, pool_network::asset::PairType};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Coin, Decimal, Uint128};
 use cw_ownable::{cw_ownable_execute, cw_ownable_query};
@@ -249,4 +243,28 @@ pub struct AssetDecimalsResponse {
     pub denom: String,
     /// The decimals for the requested denom.
     pub decimals: u8,
+}
+
+/// SimulationResponse returns swap simulation response
+#[cw_serde]
+pub struct SimulationResponse {
+    pub return_amount: Uint128,
+    pub spread_amount: Uint128,
+    pub swap_fee_amount: Uint128,
+    pub protocol_fee_amount: Uint128,
+    pub burn_fee_amount: Uint128,
+    #[cfg(feature = "osmosis")]
+    pub osmosis_fee_amount: Uint128,
+}
+
+/// ReverseSimulationResponse returns reverse swap simulation response
+#[cw_serde]
+pub struct ReverseSimulationResponse {
+    pub offer_amount: Uint128,
+    pub spread_amount: Uint128,
+    pub swap_fee_amount: Uint128,
+    pub protocol_fee_amount: Uint128,
+    pub burn_fee_amount: Uint128,
+    #[cfg(feature = "osmosis")]
+    pub osmosis_fee_amount: Uint128,
 }


### PR DESCRIPTION
… pool_manager package

## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Minor refactor adding (duplicating) the simulation quiery responses to the pool_manager package, as it was using the ones from the pool factory.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
