### PR TITLE
feat(smart-contracts): use response structs on all queries

### DIFF
--- a/contracts/liquidity_hub/pool-manager/src/contract.rs
+++ b/contracts/liquidity_hub/pool-manager/src/contract.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use semver::Version;
 use white_whale_std::pool_manager::{
-    ExecuteMsg, FeatureToggle, InstantiateMsg, MigrateMsg, QueryMsg,
+    ExecuteMsg, FeatureToggle, InstantiateMsg, MigrateMsg, PairInfoResponse, QueryMsg,
 };
 
 // version info for migration info
@@ -236,9 +236,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
         )?)?),
         QueryMsg::SwapRoutes {} => Ok(to_json_binary(&get_swap_routes(deps)?)?),
         QueryMsg::Ownership {} => Ok(to_json_binary(&cw_ownable::get_ownership(deps.storage)?)?),
-        QueryMsg::Pair { pair_identifier } => Ok(to_json_binary(
-            &PAIRS.load(deps.storage, &pair_identifier)?,
-        )?),
+        QueryMsg::Pair { pair_identifier } => Ok(to_json_binary(&PairInfoResponse {
+            pair_info: PAIRS.load(deps.storage, &pair_identifier)?,
+        })?),
     }
 }
 

--- a/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
@@ -1754,7 +1754,7 @@ mod swapping {
 }
 
 mod ownership {
-    use white_whale_std::pool_network::pair::FeatureToggle;
+    use white_whale_std::pool_manager::FeatureToggle;
 
     use super::*;
 

--- a/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::testing::MockStorage;
-use white_whale_std::pool_manager::{Config, SwapOperation};
+use white_whale_std::pool_manager::{Config, FeatureToggle, SwapOperation};
 use white_whale_std::pool_manager::{InstantiateMsg, PairInfo};
 
 use cosmwasm_std::{coin, Addr, Coin, Decimal, Empty, StdResult, Timestamp, Uint128, Uint64};
@@ -9,9 +9,7 @@ use cw_multi_test::{
 };
 use white_whale_std::fee::PoolFee;
 use white_whale_std::pool_network::asset::{AssetInfo, PairType};
-use white_whale_std::pool_network::pair::{
-    FeatureToggle, ReverseSimulationResponse, SimulationResponse,
-};
+use white_whale_std::pool_network::pair::{ReverseSimulationResponse, SimulationResponse};
 use white_whale_testing::multi_test::stargate_mock::StargateMock;
 
 use cw_multi_test::addons::{MockAddressGenerator, MockApiBech32};

--- a/packages/white-whale-std/src/pool_manager.rs
+++ b/packages/white-whale-std/src/pool_manager.rs
@@ -57,9 +57,7 @@ pub struct SwapRoute {
 // Used for all swap routes
 #[cw_serde]
 pub struct SwapRouteResponse {
-    pub offer_asset_denom: String,
-    pub ask_asset_denom: String,
-    pub swap_route: Vec<SwapOperation>,
+    pub swap_route: SwapRoute,
 }
 
 impl fmt::Display for SwapRoute {
@@ -204,7 +202,7 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Retrieves the contract's config.
-    #[returns(Config)]
+    #[returns(ConfigResponse)]
     Config {},
 
     /// Retrieves the decimals for the given asset.
@@ -231,13 +229,13 @@ pub enum QueryMsg {
     },
 
     /// Gets the swap route for the given offer and ask assets.
-    #[returns(Vec<SwapOperation>)]
+    #[returns(SwapRouteResponse)]
     SwapRoute {
         offer_asset_denom: String,
         ask_asset_denom: String,
     },
     /// Gets all swap routes registered
-    #[returns(Vec<SwapRouteResponse>)]
+    #[returns(SwapRoutesResponse)]
     SwapRoutes {},
 
     // /// Simulates swap operations.
@@ -253,8 +251,23 @@ pub enum QueryMsg {
     //     ask_amount: Uint128,
     //     operations: Vec<SwapOperation>,
     // },
-    #[returns(PairInfo)]
+    #[returns(PairInfoResponse)]
     Pair { pair_identifier: String },
+}
+
+#[cw_serde]
+pub struct ConfigResponse {
+    pub config: Config,
+}
+
+#[cw_serde]
+pub struct SwapRoutesResponse {
+    pub swap_routes: Vec<SwapRoute>,
+}
+
+#[cw_serde]
+pub struct PairInfoResponse {
+    pub pair_info: PairInfo,
 }
 
 /// The response for the `AssetDecimals` query.


### PR DESCRIPTION
## Description and Motivation

This PR refactors some queries to return response structs instead of plain data.

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

#319 
<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [ ] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `cargo fmt --all --`.
- [ ] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [ ] I have regenerated the schemas if needed `cargo schema`.
