### PR TITLE
Send protocol fees from pool manager via FillRewards rather than BankMsg

### DIFF
--- a/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/integration_tests.rs
@@ -1743,7 +1743,7 @@ mod swapping {
             },
         );
 
-        // Verify fee collection by querying the address of the fee_collector and checking its balance
+        // Verify fee collection by querying the address of the whale lair and checking its balance
         // Should be 297 uLUNA
         suite.query_balance(
             suite.whale_lair_addr.to_string(),


### PR DESCRIPTION
## Description and Motivation

We currently use `BankMsg::Send` when a swap has occurred to send the protocol fees to the whale-lair. This is not desired, as it does not allow the whale-lair contract to hook into receiving the assets.

## Related Issues

Closes #312.

Adding a integration test for this behaviour this is hard due to https://github.com/CosmWasm/cw-plus/issues/763. Unfortunately the cosmwasm team is not interested in addressing this issue.

---

## Checklist:

- [X] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [X] My pull request has a sound title and description (not something vague like `Update index.md`)
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation.
- [X] The code is formatted properly `cargo fmt --all --`.
- [X] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [X] I have regenerated the schemas if needed `cargo schema`.
