### PR TITLE
fix: bump white-whale-std and make the main Cargo.toml pull from cratees.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -587,7 +587,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -614,7 +614,7 @@ dependencies = [
  "vault",
  "vault_factory",
  "whale-lair",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ dependencies = [
  "serde",
  "terraswap-pair",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -787,7 +787,7 @@ dependencies = [
  "serde",
  "terraswap-token",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -804,7 +804,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1532,7 +1532,7 @@ dependencies = [
  "serde",
  "stable-swap-sim",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1602,7 +1602,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1623,7 +1623,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1657,7 +1657,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1733,7 +1733,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1754,7 +1754,7 @@ dependencies = [
  "serde",
  "thiserror",
  "vault",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "thiserror",
  "vault",
  "vault_factory",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1820,13 +1820,32 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "white-whale-testing",
 ]
 
 [[package]]
 name = "white-whale-std"
-version = "1.1.3"
+version = "1.1.4"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw2",
+ "cw20",
+ "osmosis-std-derive",
+ "prost 0.11.9",
+ "prost-types",
+ "protobuf",
+ "schemars",
+ "serde",
+ "uint",
+]
+
+[[package]]
+name = "white-whale-std"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6288f5197b4834220a801e33d84e3848eaf1bf60a07c58f90ad3f6bd366eea"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1853,7 +1872,7 @@ dependencies = [
  "schemars",
  "serde",
  "whale-lair",
- "white-whale-std",
+ "white-whale-std 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,9 @@ prost = { version = "0.11.9", default-features = false, features = [
   "prost-derive",
 ] }
 prost-types = { version = "0.11.9", default-features = false }
-white-whale-std = { version = "1.1.1", path = "packages/white-whale-std" }
+# for local development
+#white-whale-std = { path = "packages/white-whale-std" }
+white-whale-std = { version = "1.1.4" }
 white-whale-testing = { path = "./packages/white-whale-testing" }
 cw-multi-test = { version = "0.16.5" }
 uint = "0.9.5"

--- a/packages/white-whale-std/Cargo.toml
+++ b/packages/white-whale-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "white-whale-std"
-version = "1.1.3"
+version = "1.1.4"
 edition.workspace = true
 authors = [
   "Kerber0x <kerber0x@protonmail.com>",


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR bumps white-whale-std and makes the project pull the version from crates.io.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
