### PR TITLE
Feat/enable query reverse simulate swap operations

### DIFF
--- a/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
+++ b/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
@@ -836,6 +836,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Simulates swap operations.",
         "type": "object",
         "required": [
           "simulate_swap_operations"
@@ -849,6 +850,35 @@
             ],
             "properties": {
               "offer_amount": {
+                "$ref": "#/definitions/Uint128"
+              },
+              "operations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/SwapOperation"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Simulates a reverse swap operations, i.e. given the ask asset, how much of the offer asset is needed to perform the swap.",
+        "type": "object",
+        "required": [
+          "reverse_simulate_swap_operations"
+        ],
+        "properties": {
+          "reverse_simulate_swap_operations": {
+            "type": "object",
+            "required": [
+              "ask_amount",
+              "operations"
+            ],
+            "properties": {
+              "ask_amount": {
                 "$ref": "#/definitions/Uint128"
               },
               "operations": {
@@ -1372,6 +1402,26 @@
           },
           "additionalProperties": false
         },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "reverse_simulate_swap_operations": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ReverseSimulateSwapOperationsResponse",
+      "type": "object",
+      "required": [
+        "amount"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
           "type": "string"

--- a/contracts/liquidity_hub/pool-manager/schema/raw/query.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/query.json
@@ -139,6 +139,7 @@
       "additionalProperties": false
     },
     {
+      "description": "Simulates swap operations.",
       "type": "object",
       "required": [
         "simulate_swap_operations"
@@ -152,6 +153,35 @@
           ],
           "properties": {
             "offer_amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "operations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SwapOperation"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Simulates a reverse swap operations, i.e. given the ask asset, how much of the offer asset is needed to perform the swap.",
+      "type": "object",
+      "required": [
+        "reverse_simulate_swap_operations"
+      ],
+      "properties": {
+        "reverse_simulate_swap_operations": {
+          "type": "object",
+          "required": [
+            "ask_amount",
+            "operations"
+          ],
+          "properties": {
+            "ask_amount": {
               "$ref": "#/definitions/Uint128"
             },
             "operations": {

--- a/contracts/liquidity_hub/pool-manager/schema/raw/response_to_reverse_simulate_swap_operations.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/response_to_reverse_simulate_swap_operations.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReverseSimulateSwapOperationsResponse",
+  "type": "object",
+  "required": [
+    "amount"
+  ],
+  "properties": {
+    "amount": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/liquidity_hub/pool-manager/src/contract.rs
+++ b/contracts/liquidity_hub/pool-manager/src/contract.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use crate::helpers::simulate_swap_operations;
+use crate::helpers::{reverse_simulate_swap_operations, simulate_swap_operations};
 use crate::queries::{get_swap_route, get_swap_route_creator, get_swap_routes};
 use crate::router::commands::{add_swap_routes, remove_swap_routes};
 use crate::state::{Config, MANAGER_CONFIG, PAIRS, PAIR_COUNTER};
@@ -228,12 +228,12 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
             offer_amount,
             operations,
         )?)?),
-        // QueryMsg::ReverseSimulateSwapOperations {
-        //     ask_amount,
-        //     operations,
-        // } => Ok(to_binary(&queries::reverse_simulate_swap_operations(
-        //     deps, env, ask_amount, operations,
-        // )?)?),
+        QueryMsg::ReverseSimulateSwapOperations {
+            ask_amount,
+            operations,
+        } => Ok(to_json_binary(&reverse_simulate_swap_operations(
+            deps, ask_amount, operations,
+        )?)?),
         QueryMsg::SwapRoute {
             offer_asset_denom,
             ask_asset_denom,

--- a/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
@@ -1,7 +1,6 @@
 use cosmwasm_std::testing::MockStorage;
 use white_whale_std::pool_manager::{
-    Config, FeatureToggle, PairInfoResponse, SwapOperation, SwapRouteCreatorResponse,
-    SwapRouteResponse, SwapRoutesResponse,
+    Config, FeatureToggle, PairInfoResponse, ReverseSimulateSwapOperationsResponse, SimulateSwapOperationsResponse, SwapOperation, SwapRouteCreatorResponse, SwapRouteResponse, SwapRoutesResponse
 };
 use white_whale_std::pool_manager::{InstantiateMsg, PairInfo};
 
@@ -17,7 +16,7 @@ use white_whale_std::fee::PoolFee;
 use white_whale_std::incentive_manager::PositionsResponse;
 use white_whale_std::lp_common::LP_SYMBOL;
 use white_whale_std::pool_network::asset::{AssetInfo, PairType};
-use white_whale_std::pool_network::pair::{ReverseSimulationResponse, SimulationResponse};
+use white_whale_std::pool_manager::{ReverseSimulationResponse, SimulationResponse};
 use white_whale_testing::multi_test::stargate_mock::StargateMock;
 
 fn contract_pool_manager() -> Box<dyn Contract<Empty>> {
@@ -603,6 +602,44 @@ impl TestingSuite {
                     pair_identifier,
                 },
             );
+
+        result(pair_info_response);
+
+        self
+    }
+
+    pub(crate) fn query_simulate_swap_operations(
+        &mut self,
+        offer_amount: Uint128,
+        operations: Vec<SwapOperation>,
+        result: impl Fn(StdResult<SimulateSwapOperationsResponse>),
+    ) -> &mut Self {
+        let pair_info_response: StdResult<SimulateSwapOperationsResponse> = self.app.wrap().query_wasm_smart(
+            &self.pool_manager_addr,
+            &white_whale_std::pool_manager::QueryMsg::SimulateSwapOperations {
+                offer_amount,
+                operations,
+            },
+        );
+
+        result(pair_info_response);
+
+        self
+    }
+
+    pub(crate) fn query_reverse_simulate_swap_operations(
+        &mut self,
+        ask_amount: Uint128,
+        operations: Vec<SwapOperation>,
+        result: impl Fn(StdResult<ReverseSimulateSwapOperationsResponse>),
+    ) -> &mut Self {
+        let pair_info_response: StdResult<ReverseSimulateSwapOperationsResponse> = self.app.wrap().query_wasm_smart(
+            &self.pool_manager_addr,
+            &white_whale_std::pool_manager::QueryMsg::ReverseSimulateSwapOperations {
+                ask_amount,
+                operations,
+            },
+        );
 
         result(pair_info_response);
 

--- a/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
@@ -1,6 +1,8 @@
 use cosmwasm_std::testing::MockStorage;
 use white_whale_std::pool_manager::{
-    Config, FeatureToggle, PairInfoResponse, ReverseSimulateSwapOperationsResponse, SimulateSwapOperationsResponse, SwapOperation, SwapRouteCreatorResponse, SwapRouteResponse, SwapRoutesResponse
+    Config, FeatureToggle, PairInfoResponse, ReverseSimulateSwapOperationsResponse,
+    SimulateSwapOperationsResponse, SwapOperation, SwapRouteCreatorResponse, SwapRouteResponse,
+    SwapRoutesResponse,
 };
 use white_whale_std::pool_manager::{InstantiateMsg, PairInfo};
 
@@ -15,8 +17,8 @@ use white_whale_std::epoch_manager::epoch_manager::{Epoch, EpochConfig};
 use white_whale_std::fee::PoolFee;
 use white_whale_std::incentive_manager::PositionsResponse;
 use white_whale_std::lp_common::LP_SYMBOL;
-use white_whale_std::pool_network::asset::{AssetInfo, PairType};
 use white_whale_std::pool_manager::{ReverseSimulationResponse, SimulationResponse};
+use white_whale_std::pool_network::asset::{AssetInfo, PairType};
 use white_whale_testing::multi_test::stargate_mock::StargateMock;
 
 fn contract_pool_manager() -> Box<dyn Contract<Empty>> {
@@ -614,13 +616,14 @@ impl TestingSuite {
         operations: Vec<SwapOperation>,
         result: impl Fn(StdResult<SimulateSwapOperationsResponse>),
     ) -> &mut Self {
-        let pair_info_response: StdResult<SimulateSwapOperationsResponse> = self.app.wrap().query_wasm_smart(
-            &self.pool_manager_addr,
-            &white_whale_std::pool_manager::QueryMsg::SimulateSwapOperations {
-                offer_amount,
-                operations,
-            },
-        );
+        let pair_info_response: StdResult<SimulateSwapOperationsResponse> =
+            self.app.wrap().query_wasm_smart(
+                &self.pool_manager_addr,
+                &white_whale_std::pool_manager::QueryMsg::SimulateSwapOperations {
+                    offer_amount,
+                    operations,
+                },
+            );
 
         result(pair_info_response);
 
@@ -633,13 +636,14 @@ impl TestingSuite {
         operations: Vec<SwapOperation>,
         result: impl Fn(StdResult<ReverseSimulateSwapOperationsResponse>),
     ) -> &mut Self {
-        let pair_info_response: StdResult<ReverseSimulateSwapOperationsResponse> = self.app.wrap().query_wasm_smart(
-            &self.pool_manager_addr,
-            &white_whale_std::pool_manager::QueryMsg::ReverseSimulateSwapOperations {
-                ask_amount,
-                operations,
-            },
-        );
+        let pair_info_response: StdResult<ReverseSimulateSwapOperationsResponse> =
+            self.app.wrap().query_wasm_smart(
+                &self.pool_manager_addr,
+                &white_whale_std::pool_manager::QueryMsg::ReverseSimulateSwapOperations {
+                    ask_amount,
+                    operations,
+                },
+            );
 
         result(pair_info_response);
 

--- a/packages/white-whale-std/src/pool_manager.rs
+++ b/packages/white-whale-std/src/pool_manager.rs
@@ -248,19 +248,20 @@ pub enum QueryMsg {
     #[returns(SwapRoutesResponse)]
     SwapRoutes {},
 
-    // /// Simulates swap operations.
+    /// Simulates swap operations.
     #[returns(SimulateSwapOperationsResponse)]
     SimulateSwapOperations {
         offer_amount: Uint128,
         operations: Vec<SwapOperation>,
     },
-    // /// Simulates a reverse swap operations, i.e. given the ask asset, how much of the offer asset
-    // /// is needed to perform the swap.
-    // #[returns(SimulateSwapOperationsResponse)]
-    // ReverseSimulateSwapOperations {
-    //     ask_amount: Uint128,
-    //     operations: Vec<SwapOperation>,
-    // },
+    /// Simulates a reverse swap operations, i.e. given the ask asset, how much of the offer asset
+    /// is needed to perform the swap.
+    #[returns(ReverseSimulateSwapOperationsResponse)]
+    ReverseSimulateSwapOperations {
+        ask_amount: Uint128,
+        operations: Vec<SwapOperation>,
+    },
+
     #[returns(PairInfoResponse)]
     Pair { pair_identifier: String },
     /// Retrieves the creator of the swap routes that can then remove them.
@@ -332,6 +333,11 @@ pub struct FeatureToggle {
 // We define a custom struct for each query response
 #[cw_serde]
 pub struct SimulateSwapOperationsResponse {
+    pub amount: Uint128,
+}
+
+#[cw_serde]
+pub struct ReverseSimulateSwapOperationsResponse {
     pub amount: Uint128,
 }
 


### PR DESCRIPTION
## Description and Motivation

This PR enables the reverse simulate swap operations query for the Pool Manager contract.

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues
#339 
<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
