### PR TITLE
chore: add total LP share amount to the Pair query response

### DIFF
--- a/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
+++ b/contracts/liquidity_hub/pool-manager/schema/pool-manager.json
@@ -1241,11 +1241,15 @@
       "title": "PairInfoResponse",
       "type": "object",
       "required": [
-        "pair_info"
+        "pair_info",
+        "total_share"
       ],
       "properties": {
         "pair_info": {
           "$ref": "#/definitions/PairInfo"
+        },
+        "total_share": {
+          "$ref": "#/definitions/Coin"
         }
       },
       "additionalProperties": false,

--- a/contracts/liquidity_hub/pool-manager/schema/raw/response_to_pair.json
+++ b/contracts/liquidity_hub/pool-manager/schema/raw/response_to_pair.json
@@ -3,11 +3,15 @@
   "title": "PairInfoResponse",
   "type": "object",
   "required": [
-    "pair_info"
+    "pair_info",
+    "total_share"
   ],
   "properties": {
     "pair_info": {
       "$ref": "#/definitions/PairInfo"
+    },
+    "total_share": {
+      "$ref": "#/definitions/Coin"
     }
   },
   "additionalProperties": false,

--- a/contracts/liquidity_hub/pool-manager/src/contract.rs
+++ b/contracts/liquidity_hub/pool-manager/src/contract.rs
@@ -1,8 +1,8 @@
 use crate::error::ContractError;
 use crate::helpers::{reverse_simulate_swap_operations, simulate_swap_operations};
-use crate::queries::{get_swap_route, get_swap_route_creator, get_swap_routes};
+use crate::queries::{get_pair, get_swap_route, get_swap_route_creator, get_swap_routes};
 use crate::router::commands::{add_swap_routes, remove_swap_routes};
-use crate::state::{Config, MANAGER_CONFIG, PAIRS, PAIR_COUNTER};
+use crate::state::{Config, MANAGER_CONFIG, PAIR_COUNTER};
 use crate::{liquidity, manager, queries, router, swap};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{
@@ -11,7 +11,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use semver::Version;
 use white_whale_std::pool_manager::{
-    ExecuteMsg, FeatureToggle, InstantiateMsg, MigrateMsg, PairInfoResponse, QueryMsg,
+    ExecuteMsg, FeatureToggle, InstantiateMsg, MigrateMsg, QueryMsg,
 };
 
 // version info for migration info
@@ -244,9 +244,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
         )?)?),
         QueryMsg::SwapRoutes {} => Ok(to_json_binary(&get_swap_routes(deps)?)?),
         QueryMsg::Ownership {} => Ok(to_json_binary(&cw_ownable::get_ownership(deps.storage)?)?),
-        QueryMsg::Pair { pair_identifier } => Ok(to_json_binary(&PairInfoResponse {
-            pair_info: PAIRS.load(deps.storage, &pair_identifier)?,
-        })?),
+        QueryMsg::Pair { pair_identifier } => {
+            Ok(to_json_binary(&get_pair(deps, pair_identifier)?)?)
+        }
         QueryMsg::SwapRouteCreator {
             offer_asset_denom,
             ask_asset_denom,

--- a/contracts/liquidity_hub/pool-manager/src/queries.rs
+++ b/contracts/liquidity_hub/pool-manager/src/queries.rs
@@ -3,8 +3,8 @@ use std::cmp::Ordering;
 use cosmwasm_std::{Coin, Decimal256, Deps, Env, Fraction, Order, StdResult, Uint128};
 
 use white_whale_std::pool_manager::{
-    AssetDecimalsResponse, Config, SwapRoute, SwapRouteCreatorResponse, SwapRouteResponse,
-    SwapRoutesResponse,
+    AssetDecimalsResponse, Config, PairInfoResponse, SwapRoute, SwapRouteCreatorResponse,
+    SwapRouteResponse, SwapRoutesResponse,
 };
 use white_whale_std::pool_network::{
     asset::PairType,
@@ -12,7 +12,7 @@ use white_whale_std::pool_network::{
     // router::SimulateSwapOperationsResponse,
 };
 
-use crate::state::MANAGER_CONFIG;
+use crate::state::{MANAGER_CONFIG, PAIRS};
 use crate::{
     helpers::{self, calculate_stableswap_y, StableSwapDirection},
     state::get_pair_by_identifier,
@@ -304,6 +304,17 @@ pub fn get_swap_route_creator(
             })?;
     Ok(SwapRouteCreatorResponse {
         creator: swap_operations.creator,
+    })
+}
+
+/// Gets the pair info for a given pair identifier. Returns a [PairInfoResponse].
+pub fn get_pair(deps: Deps, pair_identifier: String) -> Result<PairInfoResponse, ContractError> {
+    let pair = PAIRS.load(deps.storage, &pair_identifier)?;
+    let total_share = deps.querier.query_supply(pair.lp_denom)?;
+
+    Ok(PairInfoResponse {
+        pair_info: PAIRS.load(deps.storage, &pair_identifier)?,
+        total_share,
     })
 }
 

--- a/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
+++ b/contracts/liquidity_hub/pool-manager/src/tests/suite.rs
@@ -681,23 +681,6 @@ impl TestingSuite {
         self
     }
 
-    pub(crate) fn _query_lp_token(&mut self, identifier: String, _sender: String) -> String {
-        // Get the LP token from Config
-        let lp_token_response: PairInfo = self
-            .app
-            .wrap()
-            .query_wasm_smart(
-                &self.pool_manager_addr,
-                &white_whale_std::pool_manager::QueryMsg::Pair {
-                    pair_identifier: identifier,
-                },
-            )
-            .unwrap();
-
-        // Get balance of LP token, if native we can just query balance otherwise we need to go to cw20
-        lp_token_response.lp_denom
-    }
-
     /// Retrieves the current configuration of the pool manager contract.
     pub(crate) fn query_config(&mut self) -> Config {
         self.app

--- a/packages/white-whale-std/src/pool_manager.rs
+++ b/packages/white-whale-std/src/pool_manager.rs
@@ -285,6 +285,7 @@ pub struct SwapRoutesResponse {
 #[cw_serde]
 pub struct PairInfoResponse {
     pub pair_info: PairInfo,
+    pub total_share: Coin,
 }
 
 /// The response for the `AssetDecimals` query.


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

Adds the total LP share amount to the Pair query response, as this was a missing piece of information lost when we removed the `Pool` query. 

## Related Issues
Closes [#344](https://github.com/White-Whale-Defi-Platform/white-whale-core/issues/344)
<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
