### PR TITLE
chore: Add @nseguias to codeowners for v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # @kerber0x is the repository administrator who ensures compliance with the White Whale Repository Guideline.
 # The remaining code owners help maintain the repository.
-* @kerber0x @0xFable @kaimen-sano @Sen-Com
+* @kerber0x @0xFable @kaimen-sano @Sen-Com @nseguias
 


### PR DESCRIPTION
Adds @nseguias to CODEOWNERS but on release-v2-contracts branch. 
Will propagate to main branch once we release v2 