### PR TITLE
fix: fee distributor claim floor fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "fee_distributor"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/liquidity_hub/fee_distributor/Cargo.toml
+++ b/contracts/liquidity_hub/fee_distributor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fee_distributor"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Kerber0x <kerber0x@protonmail.com>"]
 edition.workspace = true
 description = "Contract to distribute the fees collected by the Fee Collector."

--- a/contracts/liquidity_hub/fee_distributor/src/commands.rs
+++ b/contracts/liquidity_hub/fee_distributor/src/commands.rs
@@ -97,7 +97,9 @@ pub fn claim(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError
             }))?;
 
         for fee in epoch.total.iter() {
-            let reward = fee.amount * bonding_weight_response.share;
+            let reward = fee
+                .amount
+                .checked_mul_floor(bonding_weight_response.share)?;
 
             if reward.is_zero() {
                 // nothing to claim

--- a/contracts/liquidity_hub/fee_distributor/src/error.rs
+++ b/contracts/liquidity_hub/fee_distributor/src/error.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{DivideByZeroError, OverflowError, StdError, Uint64};
+use cosmwasm_std::{
+    CheckedMultiplyFractionError, DivideByZeroError, OverflowError, StdError, Uint64,
+};
 use cw_utils::ParseReplyError;
 use semver::Version;
 use thiserror::Error;
@@ -52,6 +54,9 @@ pub enum ContractError {
 
     #[error("{0}")]
     ParseReplyError(#[from] ParseReplyError),
+
+    #[error("{0}")]
+    CheckedMultiplyFractionError(#[from] CheckedMultiplyFractionError),
 
     #[error("Attempt to migrate to version {new_version}, but contract is on a higher version {current_version}")]
     MigrateInvalidVersion {


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR makes the fee distributor use `checked_mul_floor` when calculating rewards to be distributed. This might fix the issue some users have when claiming rewards.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
