### PR TITLE
fix(bonding_manager): fix validation of epoch when bonding/unbonding

### DIFF
--- a/contracts/liquidity_hub/bonding-manager/schema/bonding-manager.json
+++ b/contracts/liquidity_hub/bonding-manager/schema/bonding-manager.json
@@ -178,6 +178,28 @@
         ]
       },
       {
+        "description": "Claims the available rewards on behalf of the specified address. Only executable by the contract.",
+        "type": "object",
+        "required": [
+          "claim_for_addr"
+        ],
+        "properties": {
+          "claim_for_addr": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Fills the contract with new rewards.",
         "type": "string",
         "enum": [

--- a/contracts/liquidity_hub/bonding-manager/schema/raw/execute.json
+++ b/contracts/liquidity_hub/bonding-manager/schema/raw/execute.json
@@ -117,6 +117,28 @@
       ]
     },
     {
+      "description": "Claims the available rewards on behalf of the specified address. Only executable by the contract.",
+      "type": "object",
+      "required": [
+        "claim_for_addr"
+      ],
+      "properties": {
+        "claim_for_addr": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Fills the contract with new rewards.",
       "type": "string",
       "enum": [

--- a/contracts/liquidity_hub/bonding-manager/src/bonding/commands.rs
+++ b/contracts/liquidity_hub/bonding-manager/src/bonding/commands.rs
@@ -16,12 +16,12 @@ use crate::{helpers, ContractError};
 pub(crate) fn bond(
     mut deps: DepsMut,
     info: MessageInfo,
-    _env: Env,
+    env: Env,
     asset: Coin,
 ) -> Result<Response, ContractError> {
     helpers::validate_buckets_not_empty(&deps)?;
     helpers::validate_claimed(&deps, &info)?;
-    helpers::validate_bonding_for_current_epoch(&deps)?;
+    helpers::validate_bonding_for_current_epoch(&deps, &env)?;
 
     let config = CONFIG.load(deps.storage)?;
     let current_epoch: white_whale_std::epoch_manager::epoch_manager::EpochResponse =
@@ -111,7 +111,7 @@ pub(crate) fn unbond(
     );
 
     helpers::validate_claimed(&deps, &info)?;
-    helpers::validate_bonding_for_current_epoch(&deps)?;
+    helpers::validate_bonding_for_current_epoch(&deps, &env)?;
 
     let bonds_by_receiver = get_bonds_by_receiver(
         deps.storage,

--- a/contracts/liquidity_hub/bonding-manager/src/contract.rs
+++ b/contracts/liquidity_hub/bonding-manager/src/contract.rs
@@ -1,12 +1,15 @@
 use crate::error::ContractError;
 use crate::helpers::{self, validate_growth_rate};
-use crate::state::{BONDING_ASSETS_LIMIT, BOND_COUNTER, CONFIG, UPCOMING_REWARD_BUCKET};
+use crate::state::{
+    BONDING_ASSETS_LIMIT, BOND_COUNTER, CONFIG, TMP_BOND_ACTION, UPCOMING_REWARD_BUCKET,
+};
 use crate::{bonding, commands, queries, rewards};
 use cosmwasm_std::{ensure, entry_point, Addr, Reply};
 use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
 use cw2::{get_contract_version, set_contract_version};
 use white_whale_std::bonding_manager::{
-    Config, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, UpcomingRewardBucket,
+    Config, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, TemporalBondAction,
+    UpcomingRewardBucket,
 };
 
 // version info for migration info
@@ -14,6 +17,8 @@ const CONTRACT_NAME: &str = "white_whale-bonding_manager";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const LP_WITHDRAWAL_REPLY_ID: u64 = 0;
+pub const CLAIM_REPLY_ID: u64 = 1;
+pub const NEW_EPOCH_CREATION_REPLY_ID: u64 = 2;
 
 #[entry_point]
 pub fn instantiate(
@@ -59,9 +64,40 @@ pub fn instantiate(
 
 // Reply entrypoint handling LP withdraws from fill_rewards
 #[entry_point]
-pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractError> {
     match msg.id {
         LP_WITHDRAWAL_REPLY_ID => rewards::commands::handle_lp_withdrawal_reply(deps, msg),
+        NEW_EPOCH_CREATION_REPLY_ID => {
+            let TemporalBondAction {
+                sender,
+                coin,
+                is_bond,
+            } = TMP_BOND_ACTION.load(deps.storage)?;
+
+            TMP_BOND_ACTION.remove(deps.storage);
+
+            if is_bond {
+                bonding::commands::bond(
+                    deps,
+                    &MessageInfo {
+                        sender,
+                        funds: vec![coin.clone()],
+                    },
+                    env,
+                    &coin,
+                )
+            } else {
+                bonding::commands::unbond(
+                    deps,
+                    &MessageInfo {
+                        sender,
+                        funds: vec![],
+                    },
+                    env,
+                    &coin,
+                )
+            }
+        }
         _ => Err(ContractError::Unauthorized),
     }
 }
@@ -76,11 +112,11 @@ pub fn execute(
     match msg {
         ExecuteMsg::Bond => {
             let asset_to_bond = helpers::validate_funds(&deps, &info)?;
-            bonding::commands::bond(deps, info, env, asset_to_bond)
+            bonding::commands::bond(deps, &info, env, &asset_to_bond)
         }
         ExecuteMsg::Unbond { asset } => {
             cw_utils::nonpayable(&info)?;
-            bonding::commands::unbond(deps, info, env, asset)
+            bonding::commands::unbond(deps, &info, env, &asset)
         }
         ExecuteMsg::Withdraw { denom } => {
             cw_utils::nonpayable(&info)?;

--- a/contracts/liquidity_hub/bonding-manager/src/helpers.rs
+++ b/contracts/liquidity_hub/bonding-manager/src/helpers.rs
@@ -501,7 +501,7 @@ pub fn fill_upcoming_reward_bucket(deps: DepsMut, funds: Coin) -> StdResult<()> 
 /// Creates a [SubMsg] for the given [TemporalBondAction].
 pub fn temporal_bond_action_response(
     deps: &mut DepsMut,
-    contract_addr: Addr,
+    contract_addr: &Addr,
     temporal_bond_action: TemporalBondAction,
     error: ContractError,
 ) -> Result<Response, ContractError> {
@@ -532,7 +532,7 @@ pub fn temporal_bond_action_response(
 /// If there are unclaimed rewards, creates a [SubMsg] to claim rewards. Used to trigger when the
 /// user is bonding/unbonding, and it hasn't claimed pending rewards yet.
 fn create_temporal_bond_action_submsg(
-    contract_addr: Addr,
+    contract_addr: &Addr,
     msg: &impl Serialize,
 ) -> Result<SubMsg, ContractError> {
     Ok(SubMsg::reply_on_success(

--- a/contracts/liquidity_hub/bonding-manager/src/state.rs
+++ b/contracts/liquidity_hub/bonding-manager/src/state.rs
@@ -2,13 +2,14 @@ use cosmwasm_std::{Addr, Decimal, DepsMut, Order, StdError, StdResult, Storage, 
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 
 use white_whale_std::bonding_manager::{
-    Bond, Config, GlobalIndex, RewardBucket, UpcomingRewardBucket,
+    Bond, Config, GlobalIndex, RewardBucket, TemporalBondAction, UpcomingRewardBucket,
 };
 
 use crate::ContractError;
 
 pub const BONDING_ASSETS_LIMIT: usize = 2;
 pub const CONFIG: Item<Config> = Item::new("config");
+pub const TMP_BOND_ACTION: Item<TemporalBondAction> = Item::new("temporal_bond_action");
 
 /// A monotonically increasing counter to generate unique bond ids.
 pub const BOND_COUNTER: Item<u64> = Item::new("bond_counter");

--- a/contracts/liquidity_hub/bonding-manager/src/tests/queries.rs
+++ b/contracts/liquidity_hub/bonding-manager/src/tests/queries.rs
@@ -40,7 +40,7 @@ fn test_queries() {
         });
 
     suite
-        .fast_forward(259_200)
+        .add_one_day()
         // epoch 1
         .create_new_epoch()
         .create_pair(
@@ -95,6 +95,7 @@ fn test_queries() {
                 result.unwrap();
             },
         )
+        .add_one_day()
         // epoch 2
         .create_new_epoch()
         .bond(creator.clone(), &coins(1_000u128, "ampWHALE"), |res| {
@@ -134,7 +135,7 @@ fn test_queries() {
         );
 
     // epoch 3
-    suite.create_new_epoch();
+    suite.add_one_day().create_new_epoch();
 
     suite
         .query_global_index(None, |result| {

--- a/contracts/liquidity_hub/bonding-manager/src/tests/suite.rs
+++ b/contracts/liquidity_hub/bonding-manager/src/tests/suite.rs
@@ -14,7 +14,7 @@ use white_whale_std::bonding_manager::{
     UnbondingResponse, WithdrawableResponse,
 };
 use white_whale_std::bonding_manager::{ClaimableRewardBucketsResponse, RewardBucket};
-use white_whale_std::epoch_manager::epoch_manager::{Epoch as EpochV2, EpochConfig};
+use white_whale_std::epoch_manager::epoch_manager::{Epoch as EpochV2, EpochConfig, EpochResponse};
 use white_whale_std::pool_manager::PoolType;
 
 pub fn bonding_manager_contract() -> Box<dyn Contract<Empty>> {
@@ -578,6 +578,27 @@ impl TestingSuite {
             .unwrap();
 
         response(Ok((self, rewards_response)));
+
+        self
+    }
+
+    // Epoch Manager queries
+
+    #[track_caller]
+    pub(crate) fn query_current_epoch(
+        &mut self,
+        response: impl Fn(StdResult<(&mut Self, EpochResponse)>),
+    ) -> &mut Self {
+        let epoch_response: EpochResponse = self
+            .app
+            .wrap()
+            .query_wasm_smart(
+                &self.epoch_manager_addr,
+                &white_whale_std::epoch_manager::epoch_manager::QueryMsg::CurrentEpoch,
+            )
+            .unwrap();
+
+        response(Ok((self, epoch_response)));
 
         self
     }

--- a/packages/white-whale-std/src/bonding_manager.rs
+++ b/packages/white-whale-std/src/bonding_manager.rs
@@ -263,6 +263,13 @@ pub struct ClaimableRewardBucketsResponse {
     pub reward_buckets: Vec<RewardBucket>,
 }
 
+#[cw_serde]
+pub struct TemporalBondAction {
+    pub sender: Addr,
+    pub coin: Coin,
+    pub is_bond: bool,
+}
+
 /// Creates a message to fill rewards on the whale lair contract.
 pub fn fill_rewards_msg(contract_addr: String, assets: Vec<Coin>) -> StdResult<CosmosMsg> {
     Ok(CosmosMsg::Wasm(WasmMsg::Execute {

--- a/packages/white-whale-std/src/bonding_manager.rs
+++ b/packages/white-whale-std/src/bonding_manager.rs
@@ -1,4 +1,5 @@
 use crate::epoch_manager::epoch_manager::Epoch;
+use std::fmt::Display;
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{
@@ -154,6 +155,8 @@ pub enum ExecuteMsg {
     },
     /// Claims the available rewards
     Claim,
+    /// Claims the available rewards on behalf of the specified address. Only executable by the contract.
+    ClaimForAddr { address: String },
     /// Fills the contract with new rewards.
     FillRewards,
     /// Epoch Changed hook implementation. Creates a new reward bucket for the rewards flowing from
@@ -267,7 +270,22 @@ pub struct ClaimableRewardBucketsResponse {
 pub struct TemporalBondAction {
     pub sender: Addr,
     pub coin: Coin,
-    pub is_bond: bool,
+    pub action: BondAction,
+}
+
+#[cw_serde]
+pub enum BondAction {
+    Bond,
+    Unbond,
+}
+
+impl Display for BondAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BondAction::Bond => write!(f, "bond"),
+            BondAction::Unbond => write!(f, "unbond"),
+        }
+    }
 }
 
 /// Creates a message to fill rewards on the whale lair contract.


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR improves the validation when bonding/unbonding so it makes sure not only that a new epoch has been created but that the system is up to date, i.e. if an epoch is due to be created the contract won't let you bond or unbond. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
