### PR TITLE
refactor: uses procedural macro to replace the MigrateInvalidVersion on V2 contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-migrate-error-derive",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus",
@@ -293,6 +294,19 @@ dependencies = [
  "cw-utils",
  "schemars",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-migrate-error-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431d51e7f8b028e8a09d2125be3c6b8661b512ba40daadf6e0ffc4aadcef604b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.68",
  "thiserror",
 ]
 
@@ -534,6 +548,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
+ "cw-migrate-error-derive",
  "cw-storage-plus",
  "cw-utils",
  "cw2",
@@ -761,6 +776,7 @@ dependencies = [
  "bonding-manager",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-migrate-error-derive",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus",
@@ -959,6 +975,7 @@ dependencies = [
  "bonding-manager",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-migrate-error-derive",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus",
@@ -989,9 +1006,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1059,7 +1076,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1160,9 +1177,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1314,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1344,7 +1361,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1480,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1597,7 +1614,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1608,28 +1625,28 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1695,6 +1712,7 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-migrate-error-derive",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ prost = { version = "0.11.9", default-features = false, features = [
   "prost-derive",
 ] }
 test-case = { version = "3.3.1" }
+cw-migrate-error-derive = { version = "0.1.0" }
 
 # contracts
 whale-lair = { path = "./contracts/liquidity_hub/whale_lair" }

--- a/contracts/liquidity_hub/bonding-manager/Cargo.toml
+++ b/contracts/liquidity_hub/bonding-manager/Cargo.toml
@@ -41,6 +41,7 @@ white-whale-std.workspace = true
 cw-utils.workspace = true
 pool-manager.workspace = true
 cw-ownable.workspace = true
+cw-migrate-error-derive.workspace = true
 
 [dev-dependencies]
 cw-multi-test.workspace = true

--- a/contracts/liquidity_hub/bonding-manager/src/error.rs
+++ b/contracts/liquidity_hub/bonding-manager/src/error.rs
@@ -1,11 +1,12 @@
 use cosmwasm_std::{
     CheckedMultiplyFractionError, DivideByZeroError, OverflowError, StdError, Uint128,
 };
+use cw_migrate_error_derive::cw_migrate_invalid_version_error;
 use cw_ownable::OwnershipError;
 use cw_utils::PaymentError;
-use semver::Version;
 use thiserror::Error;
 
+#[cw_migrate_invalid_version_error]
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
@@ -54,12 +55,6 @@ pub enum ContractError {
 
     #[error("Nothing to withdraw")]
     NothingToWithdraw,
-
-    #[error("Attempt to migrate to version {new_version}, but contract is on a higher version {current_version}")]
-    MigrateInvalidVersion {
-        new_version: Version,
-        current_version: Version,
-    },
 
     #[error("There are unclaimed rewards available. Claim them before attempting to bond/unbond")]
     UnclaimedRewards,

--- a/contracts/liquidity_hub/epoch-manager/Cargo.toml
+++ b/contracts/liquidity_hub/epoch-manager/Cargo.toml
@@ -35,3 +35,4 @@ thiserror.workspace = true
 white-whale-std.workspace = true
 cw-controllers.workspace = true
 cw-utils.workspace = true
+cw-migrate-error-derive.workspace = true

--- a/contracts/liquidity_hub/epoch-manager/src/error.rs
+++ b/contracts/liquidity_hub/epoch-manager/src/error.rs
@@ -1,9 +1,10 @@
 use cosmwasm_std::StdError;
 use cw_controllers::{AdminError, HookError};
+use cw_migrate_error_derive::cw_migrate_invalid_version_error;
 use cw_utils::PaymentError;
-use semver::Version;
 use thiserror::Error;
 
+#[cw_migrate_invalid_version_error]
 #[derive(Error, Debug)]
 pub enum ContractError {
     #[error("{0}")]
@@ -23,12 +24,6 @@ pub enum ContractError {
 
     #[error("Semver parsing error: {0}")]
     SemVer(String),
-
-    #[error("Attempt to migrate to version {new_version}, but contract is on a higher version {current_version}")]
-    MigrateInvalidVersion {
-        new_version: Version,
-        current_version: Version,
-    },
 
     #[error("The current epoch epoch has not expired yet.")]
     CurrentEpochNotExpired,

--- a/contracts/liquidity_hub/incentive-manager/Cargo.toml
+++ b/contracts/liquidity_hub/incentive-manager/Cargo.toml
@@ -36,6 +36,7 @@ thiserror.workspace = true
 white-whale-std.workspace = true
 cw-utils.workspace = true
 cw-ownable.workspace = true
+cw-migrate-error-derive.workspace = true
 
 [dev-dependencies]
 cw-multi-test.workspace = true

--- a/contracts/liquidity_hub/incentive-manager/src/error.rs
+++ b/contracts/liquidity_hub/incentive-manager/src/error.rs
@@ -2,13 +2,14 @@ use cosmwasm_std::{
     CheckedFromRatioError, CheckedMultiplyFractionError, ConversionOverflowError,
     DivideByZeroError, OverflowError, StdError, Uint128,
 };
+use cw_migrate_error_derive::cw_migrate_invalid_version_error;
 use cw_ownable::OwnershipError;
 use cw_utils::PaymentError;
-use semver::Version;
 use thiserror::Error;
 
 use white_whale_std::incentive_manager::EpochId;
 
+#[cw_migrate_invalid_version_error]
 #[derive(Error, Debug)]
 pub enum ContractError {
     #[error("{0}")]
@@ -148,12 +149,6 @@ pub enum ContractError {
 
     #[error("There's no snapshot of the LP weight in the contract for the epoch {epoch_id}")]
     LpWeightNotFound { epoch_id: EpochId },
-
-    #[error("Attempt to migrate to version {new_version}, but contract is on a higher version {current_version}")]
-    MigrateInvalidVersion {
-        new_version: Version,
-        current_version: Version,
-    },
 }
 
 impl From<semver::Error> for ContractError {

--- a/contracts/liquidity_hub/pool-manager/Cargo.toml
+++ b/contracts/liquidity_hub/pool-manager/Cargo.toml
@@ -48,6 +48,7 @@ cw-utils.workspace = true
 cw-ownable.workspace = true
 sha2.workspace = true
 semver.workspace = true
+cw-migrate-error-derive.workspace = true
 
 [dev-dependencies]
 cw-multi-test.workspace = true

--- a/contracts/liquidity_hub/pool-manager/src/error.rs
+++ b/contracts/liquidity_hub/pool-manager/src/error.rs
@@ -4,12 +4,13 @@ use cosmwasm_std::{
     ConversionOverflowError, DivideByZeroError, Instantiate2AddressError, OverflowError, StdError,
     Uint128,
 };
+use cw_migrate_error_derive::cw_migrate_invalid_version_error;
 use cw_ownable::OwnershipError;
 use cw_utils::PaymentError;
-use semver::Version;
 use thiserror::Error;
 use white_whale_std::pool_manager::SwapRoute;
 
+#[cw_migrate_invalid_version_error]
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     // Handle all normal errors from the StdError
@@ -37,12 +38,6 @@ pub enum ContractError {
     // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
     #[error("The provided assets are both the same")]
     SameAsset,
-
-    #[error("Attempt to migrate to version {new_version}, but contract is on a higher version {current_version}")]
-    MigrateInvalidVersion {
-        new_version: Version,
-        current_version: Version,
-    },
 
     #[error(
         "Assertion failed; minimum receive amount: {minimum_receive}, swap amount: {swap_amount}"

--- a/contracts/liquidity_hub/vault-manager/Cargo.toml
+++ b/contracts/liquidity_hub/vault-manager/Cargo.toml
@@ -43,6 +43,7 @@ thiserror.workspace = true
 white-whale-std.workspace = true
 cw-utils.workspace = true
 cw-ownable.workspace = true
+cw-migrate-error-derive.workspace = true
 
 [dev-dependencies]
 cw-multi-test.workspace = true

--- a/contracts/liquidity_hub/vault-manager/src/error.rs
+++ b/contracts/liquidity_hub/vault-manager/src/error.rs
@@ -1,9 +1,10 @@
 use cosmwasm_std::{ConversionOverflowError, DivideByZeroError, OverflowError, StdError, Uint128};
+use cw_migrate_error_derive::cw_migrate_invalid_version_error;
 use cw_ownable::OwnershipError;
 use cw_utils::PaymentError;
-use semver::Version;
 use thiserror::Error;
 
+#[cw_migrate_invalid_version_error]
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
@@ -24,12 +25,6 @@ pub enum ContractError {
     ExistingVault {
         asset_denom: String,
         identifier: String,
-    },
-
-    #[error("Attempt to migrate to version {new_version}, but contract is on a higher version {current_version}")]
-    MigrateInvalidVersion {
-        new_version: Version,
-        current_version: Version,
     },
 
     #[error("Vault doesn't exist")]


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR uses the macro from https://crates.io/crates/cw-migrate-error-derive to generate the previous `MigrateInvalidVersion` across all the V2 contracts.

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
