### PR TITLE
chore: add LP mint calculation for stableswap pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "terraswap-pair"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "anybuf",
  "cosmwasm-schema",

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-pair"
-version = "1.3.7"
+version = "1.3.8"
 authors = [
   "Terraform Labs, PTE.",
   "DELIGHT LABS",

--- a/contracts/liquidity_hub/pool-network/terraswap_pair/src/lib.rs
+++ b/contracts/liquidity_hub/pool-network/terraswap_pair/src/lib.rs
@@ -7,10 +7,9 @@ pub mod state;
 mod error;
 mod helpers;
 mod math;
+mod migrations;
 mod queries;
 mod response;
-
-mod migrations;
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
 pub mod tests;

--- a/scripts/deployment/deploy_env/mainnets/terra.env
+++ b/scripts/deployment/deploy_env/mainnets/terra.env
@@ -1,4 +1,4 @@
 export CHAIN_ID="phoenix-1"
 export DENOM="uluna"
 export BINARY="terrad"
-export RPC="https://ww-terra-rpc.polkachu.com:443"
+export RPC="https://rpc.lavenderfive.com:443/terra2"


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR fixes the LP mint calculation when providing liquidity for stableswap pairs. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-core/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to White Whale Migaloo!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-core/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x]  I updated/added relevant documentation.
- [x] The code is formatted properly `cargo fmt --all --`.
- [x] Clippy doesn't report any issues `cargo clippy -- -D warnings`.
- [x] I have regenerated the schemas if needed `cargo schema`.
